### PR TITLE
Horizun 0.9: one-action CLI installation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,3 @@
 /CODE-SIGNING-POLICY.md @pablo-horizun @isabela-horizun @daniela-horizun
 /docs/PRIVACY.md @pablo-horizun @isabela-horizun @daniela-horizun
 /docs/RELEASE-POLICY.md @pablo-horizun @isabela-horizun @daniela-horizun
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Signing and release controls require review from a Horizun Group owner.
+/.github/workflows/ @pablo-horizun @isabela-horizun @daniela-horizun
+/.signpath/ @pablo-horizun @isabela-horizun @daniela-horizun
+/CODE-SIGNING-POLICY.md @pablo-horizun @isabela-horizun @daniela-horizun
+/docs/PRIVACY.md @pablo-horizun @isabela-horizun @daniela-horizun
+/docs/RELEASE-POLICY.md @pablo-horizun @isabela-horizun @daniela-horizun
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           pwsh scripts/install-completion.tests.ps1
           pwsh scripts/manifest-integrity.tests.ps1
           pwsh scripts/register-client.tests.ps1
+          pwsh scripts/server-update.tests.ps1
           pwsh scripts/public-consistency.tests.ps1
 
       - name: Whitespace and line-ending hygiene
@@ -261,6 +262,10 @@ jobs:
           if ($missing.Count -gt 0) { throw "no payload for $($missing -join ', ') - this runner is missing those Revit versions" }
 
           Write-Host "validated commit $($doc.Commit), server + $($doc.Plugins.Count) per-year payloads, all distinct, full hashes"
+
+      - name: Prove an active CLI update stops only the installed server path
+        shell: pwsh
+        run: pwsh scripts/server-update.tests.ps1 -RequireWindows
 
       # The full check, with the wordlist that lives on this runner. -RequireTerms
       # makes a MISSING wordlist a failure: at a release gate, "the name check did

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           pwsh scripts/install-completion.tests.ps1
           pwsh scripts/manifest-integrity.tests.ps1
           pwsh scripts/register-client.tests.ps1
+          pwsh scripts/scan-sensitive.tests.ps1
           pwsh scripts/server-update.tests.ps1
           pwsh scripts/public-consistency.tests.ps1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,24 +293,27 @@ jobs:
           & $tool validate --input-file dist/sbom.json --input-format json --input-version v1_6 --fail-on-errors
           if ($LASTEXITCODE -ne 0) { throw "CycloneDX validation failed ($LASTEXITCODE)" }
 
-      - name: Sign stable payload, compile installer, and sign the wrapper
+      - name: Compile the installer and sign releases from 1.0 onward
         shell: pwsh
         run: |
-          $stableTag = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true'
+          $releaseTag = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true'
+          $requiresPublicSignature = $releaseTag -and ([version]('${{ github.ref_name }}'.TrimStart('v'))).Major -ge 1
           $thumbprint = '${{ vars.SIGNING_CERT_THUMBPRINT }}'.Trim()
-          if ($stableTag -and -not $thumbprint) {
-            throw 'Stable publication requires repository variable SIGNING_CERT_THUMBPRINT and its private key on the release runner. No unsigned exception exists for a tag.'
+          if ($requiresPublicSignature -and -not $thumbprint) {
+            throw 'Horizun 1.0 and later require repository variable SIGNING_CERT_THUMBPRINT and its private key on the release runner. There is no unsigned exception from 1.0 onward.'
           }
           try {
-            if ($stableTag) {
+            if ($requiresPublicSignature) {
               pwsh scripts/sign.ps1 -Thumbprint $thumbprint
               if ($LASTEXITCODE -ne 0) { throw "staged payload signing failed ($LASTEXITCODE)" }
+            } elseif ($releaseTag) {
+              Write-Host '::warning::This 0.x release is intentionally unsigned. Verify SHA256SUMS.txt before installation. Public signing becomes mandatory at 1.0.0.'
             }
 
             pwsh scripts/pack.ps1 -InstallerOnly
             if ($LASTEXITCODE -ne 0) { throw "installer compilation failed ($LASTEXITCODE)" }
 
-            if ($stableTag) {
+            if ($requiresPublicSignature) {
               # The second pass skips the already-signed stage and signs the new
               # setup.exe. Wrapper and payload are separate Authenticode objects.
               pwsh scripts/sign.ps1 -Thumbprint $thumbprint
@@ -361,13 +364,14 @@ jobs:
           )
           if (-not (Test-Path $archive)) { throw 'stage.zip was not created' }
 
-      # Pull requests may exercise the complete packaging path before the signing
-      # identity is provisioned. Stable tags may not: public distribution that
-      # raises an unknown-publisher dialog is not the promised install experience.
-      - name: Enforce stable signing policy
+      # 0.x releases may ship unsigned while the public identity is pending, but
+      # they must say so. Starting with 1.0, unknown-publisher distribution is a
+      # hard release failure with no bypass.
+      - name: Enforce versioned signing policy
         shell: pwsh
         run: |
-          $stableTag = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true'
+          $releaseTag = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true'
+          $requiresPublicSignature = $releaseTag -and ([version]('${{ github.ref_name }}'.TrimStart('v'))).Major -ge 1
           $unsigned = @()
           $selfSigned = @()
           $untimestamped = @()
@@ -384,12 +388,16 @@ jobs:
               $untimestamped += $f.FullName
             }
           }
-          if ($stableTag -and ($unsigned.Count -gt 0 -or $selfSigned.Count -gt 0 -or $untimestamped.Count -gt 0)) {
+          if ($requiresPublicSignature -and ($unsigned.Count -gt 0 -or $selfSigned.Count -gt 0 -or $untimestamped.Count -gt 0)) {
             $details = @($unsigned) + @($selfSigned) + @($untimestamped | ForEach-Object { "${_}: no trusted timestamp" })
-            throw "Stable release contains unsigned, invalid, self-signed or untimestamped own binaries:`n  - $($details -join "`n  - ")"
+            throw "Horizun 1.0+ release contains unsigned, invalid, self-signed or untimestamped own binaries:`n  - $($details -join "`n  - ")"
           }
           if ($unsigned.Count -gt 0 -or $selfSigned.Count -gt 0 -or $untimestamped.Count -gt 0) {
-            Write-Host "::warning::non-tag package is not publicly signed; stable tags enforce this as a failure"
+            if ($releaseTag) {
+              Write-Host "::warning::0.x release is not publicly signed; users must verify SHA256SUMS.txt. Version 1.0+ enforces this as a failure"
+            } else {
+              Write-Host "::warning::branch package is not publicly signed"
+            }
             $unsigned | Select-Object -First 10 | ForEach-Object { Write-Host "  $_" }
             $selfSigned | Select-Object -First 10 | ForEach-Object { Write-Host "  $_" }
             $untimestamped | Select-Object -First 10 | ForEach-Object { Write-Host "  $_ : no trusted timestamp" }
@@ -465,9 +473,9 @@ jobs:
             dist/stage.zip
             dist/stage/manifest.json
 
-  # Trust is re-evaluated on a disposable Microsoft-hosted machine. A private CA
-  # added only to the release runner could otherwise report Status=Valid there
-  # while still producing an unknown publisher on every clean user's machine.
+  # The release's stated trust state is re-evaluated on a disposable
+  # Microsoft-hosted machine. For 0.x every own binary must be honestly unsigned.
+  # From 1.0 onward every own binary must be publicly trusted and timestamped.
   public-signature:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: package
@@ -481,7 +489,7 @@ jobs:
           name: horizun-mcp-package
           path: dist
 
-      - name: Require public trust and trusted timestamps on a clean runner
+      - name: Enforce the versioned trust promise on a clean runner
         shell: pwsh
         run: |
           Expand-Archive -LiteralPath dist/stage.zip -DestinationPath dist/stage -Force
@@ -490,6 +498,18 @@ jobs:
                      @(Get-ChildItem dist -Filter '*setup.exe' -File)
           if ($targets.Count -ne 8) {
             throw "Expected server exe+dll, five Revit DLLs and setup; found $($targets.Count)."
+          }
+          $major = ([version]('${{ github.ref_name }}'.TrimStart('v'))).Major
+          if ($major -lt 1) {
+            foreach ($file in $targets) {
+              $sig = Get-AuthenticodeSignature -LiteralPath $file.FullName
+              if ($sig.Status -ne 'NotSigned') {
+                throw "$($file.FullName) does not match the 0.x unsigned disclosure: $($sig.Status) - $($sig.StatusMessage)"
+              }
+              Write-Host "  disclosed unsigned $($file.Name)"
+            }
+            Write-Host '::warning::Horizun 0.x is distributed without a publicly trusted publisher. Verify SHA256SUMS.txt before running Setup.'
+            exit 0
           }
           foreach ($file in $targets) {
             $sig = Get-AuthenticodeSignature -LiteralPath $file.FullName
@@ -642,12 +662,14 @@ jobs:
       # commit, and is it the one in the tree".
       - name: Verify one clean commit from source to what is installed
         shell: pwsh
-        # Branch builds keep the explicit unsigned exception so the installer can
-        # be tested before certificate provisioning. A stable tag has no exception.
+        # Branch builds and disclosed 0.x releases keep the explicit unsigned
+        # exception. From 1.0 onward the installed artifact must be publicly signed.
         # The result path is the exact per-run file requested in the install step,
         # never the global result left by an earlier install.
         run: |
-          if ('${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true') {
+          $requiresPublicSignature = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true' -and `
+            ([version]('${{ github.ref_name }}'.TrimStart('v'))).Major -ge 1
+          if ($requiresPublicSignature) {
             pwsh scripts/verify-release.ps1 -Installed -InstallResult "$env:RUNNER_TEMP/horizun-install-result-${{ github.run_id }}.txt" -Json artifacts/live/release-chain.json
           } else {
             pwsh scripts/verify-release.ps1 -Installed -AllowUnsigned -InstallResult "$env:RUNNER_TEMP/horizun-install-result-${{ github.run_id }}.txt" -Json artifacts/live/release-chain.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           pwsh scripts/install-arguments.tests.ps1
           pwsh scripts/install-result.tests.ps1
+          pwsh scripts/install-completion.tests.ps1
           pwsh scripts/manifest-integrity.tests.ps1
           pwsh scripts/register-client.tests.ps1
           pwsh scripts/public-consistency.tests.ps1
@@ -231,7 +232,7 @@ jobs:
           $srvSha = (Get-FileHash "$stage/$($doc.Server.File)" -Algorithm SHA256).Hash.ToLower()
           if ($srvSha -ne $doc.Server.Sha256) { throw "server: manifest says $($doc.Server.Sha256), file is $srvSha" }
           if ($doc.Server.Sha256.Length -ne 64) { throw "the server hash is truncated - a prefix identifies nothing" }
-          foreach ($helper in 'register-client.ps1','verify-clients.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
+          foreach ($helper in 'register-client.ps1','verify-clients.ps1','verify-install.ps1','complete-install.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
             if (-not (Test-Path "$stage/server/client-tools/$helper")) {
               throw "installer client helper is missing: $helper"
             }
@@ -287,11 +288,36 @@ jobs:
           & $tool validate --input-file dist/sbom.json --input-format json --input-version v1_6 --fail-on-errors
           if ($LASTEXITCODE -ne 0) { throw "CycloneDX validation failed ($LASTEXITCODE)" }
 
-      - name: Compile the installer
+      - name: Sign stable payload, compile installer, and sign the wrapper
         shell: pwsh
         run: |
-          pwsh scripts/pack.ps1 -InstallerOnly
-          pwsh scripts/version-consistency.tests.ps1 -RequireStage -RequireInstaller
+          $stableTag = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true'
+          $thumbprint = '${{ vars.SIGNING_CERT_THUMBPRINT }}'.Trim()
+          if ($stableTag -and -not $thumbprint) {
+            throw 'Stable publication requires repository variable SIGNING_CERT_THUMBPRINT and its private key on the release runner. No unsigned exception exists for a tag.'
+          }
+          try {
+            if ($stableTag) {
+              pwsh scripts/sign.ps1 -Thumbprint $thumbprint
+              if ($LASTEXITCODE -ne 0) { throw "staged payload signing failed ($LASTEXITCODE)" }
+            }
+
+            pwsh scripts/pack.ps1 -InstallerOnly
+            if ($LASTEXITCODE -ne 0) { throw "installer compilation failed ($LASTEXITCODE)" }
+
+            if ($stableTag) {
+              # The second pass skips the already-signed stage and signs the new
+              # setup.exe. Wrapper and payload are separate Authenticode objects.
+              pwsh scripts/sign.ps1 -Thumbprint $thumbprint
+              if ($LASTEXITCODE -ne 0) { throw "installer signing failed ($LASTEXITCODE)" }
+            }
+            pwsh scripts/version-consistency.tests.ps1 -RequireStage -RequireInstaller
+          }
+          finally {
+            # The private key is provisioned outside the repository (certificate
+            # store, token or cloud KSP). This workflow never exports or logs it.
+            Remove-Item Env:SIGNING_CERT_PASSWORD -ErrorAction SilentlyContinue
+          }
 
       - name: Generate release checksums
         shell: pwsh
@@ -330,19 +356,38 @@ jobs:
           )
           if (-not (Test-Path $archive)) { throw 'stage.zip was not created' }
 
-      # Reported, not enforced: there is no certificate yet, and a gate nobody can
-      # pass is a gate everybody learns to bypass. See docs/security-model.md.
-      - name: Report signing status
+      # Pull requests may exercise the complete packaging path before the signing
+      # identity is provisioned. Stable tags may not: public distribution that
+      # raises an unknown-publisher dialog is not the promised install experience.
+      - name: Enforce stable signing policy
         shell: pwsh
         run: |
+          $stableTag = '${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true'
           $unsigned = @()
-          foreach ($f in Get-ChildItem dist -Recurse -Include *.exe,*.dll -File) {
+          $selfSigned = @()
+          $untimestamped = @()
+          . ./scripts/horizun-deploy.lib.ps1
+          $targets = @(@(Get-HorizunOwnBinaries 'dist/stage') | ForEach-Object { Get-Item $_ }) + `
+                     @(Get-ChildItem dist -Filter '*setup.exe' -File)
+          foreach ($f in $targets) {
             $sig = Get-AuthenticodeSignature $f.FullName
-            if ($sig.Status -ne 'Valid') { $unsigned += "$($f.Name): $($sig.Status)" }
+            if ($sig.Status -ne 'Valid') { $unsigned += "$($f.FullName): $($sig.Status)" }
+            elseif ($sig.SignerCertificate -and $sig.SignerCertificate.Subject -eq $sig.SignerCertificate.Issuer) {
+              $selfSigned += "$($f.FullName): $($sig.SignerCertificate.Subject)"
+            }
+            if ($sig.Status -eq 'Valid' -and -not $sig.TimeStamperCertificate) {
+              $untimestamped += $f.FullName
+            }
           }
-          if ($unsigned.Count -gt 0) {
-            Write-Host "::warning::$($unsigned.Count) unsigned or invalidly signed file(s) - expected until a certificate exists"
+          if ($stableTag -and ($unsigned.Count -gt 0 -or $selfSigned.Count -gt 0 -or $untimestamped.Count -gt 0)) {
+            $details = @($unsigned) + @($selfSigned) + @($untimestamped | ForEach-Object { "${_}: no trusted timestamp" })
+            throw "Stable release contains unsigned, invalid, self-signed or untimestamped own binaries:`n  - $($details -join "`n  - ")"
+          }
+          if ($unsigned.Count -gt 0 -or $selfSigned.Count -gt 0 -or $untimestamped.Count -gt 0) {
+            Write-Host "::warning::non-tag package is not publicly signed; stable tags enforce this as a failure"
             $unsigned | Select-Object -First 10 | ForEach-Object { Write-Host "  $_" }
+            $selfSigned | Select-Object -First 10 | ForEach-Object { Write-Host "  $_" }
+            $untimestamped | Select-Object -First 10 | ForEach-Object { Write-Host "  $_ : no trusted timestamp" }
           } else { Write-Host "everything is validly signed" }
 
       # WHAT THE NEXT JOB MUST BE ABLE TO CHECK IT RECEIVED.
@@ -414,6 +459,46 @@ jobs:
             dist/SHA256SUMS.txt
             dist/stage.zip
             dist/stage/manifest.json
+
+  # Trust is re-evaluated on a disposable Microsoft-hosted machine. A private CA
+  # added only to the release runner could otherwise report Status=Valid there
+  # while still producing an unknown publisher on every clean user's machine.
+  public-signature:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: package
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download the exact signed package
+        uses: actions/download-artifact@v4
+        with:
+          name: horizun-mcp-package
+          path: dist
+
+      - name: Require public trust and trusted timestamps on a clean runner
+        shell: pwsh
+        run: |
+          Expand-Archive -LiteralPath dist/stage.zip -DestinationPath dist/stage -Force
+          . ./scripts/horizun-deploy.lib.ps1
+          $targets = @(@(Get-HorizunOwnBinaries 'dist/stage') | ForEach-Object { Get-Item $_ }) + `
+                     @(Get-ChildItem dist -Filter '*setup.exe' -File)
+          if ($targets.Count -ne 8) {
+            throw "Expected server exe+dll, five Revit DLLs and setup; found $($targets.Count)."
+          }
+          foreach ($file in $targets) {
+            $sig = Get-AuthenticodeSignature -LiteralPath $file.FullName
+            if ($sig.Status -ne 'Valid') {
+              throw "$($file.FullName) is not publicly trusted on a clean Windows runner: $($sig.Status) - $($sig.StatusMessage)"
+            }
+            if (-not $sig.TimeStamperCertificate) {
+              throw "$($file.FullName) has no trusted Authenticode timestamp."
+            }
+            if ($sig.SignerCertificate.Subject -eq $sig.SignerCertificate.Issuer) {
+              throw "$($file.FullName) is self-signed, not a public publisher identity."
+            }
+            Write-Host "  trusted $($file.Name) - $($sig.SignerCertificate.Subject)"
+          }
 
   # ---------------------------------------------------------------------------
   # Install exactly once. Reinstalling the identical package before every Revit
@@ -514,7 +599,10 @@ jobs:
           # stale on any machine not on UTC.
           $startedLocal = Get-Date
           $result = Join-Path $env:RUNNER_TEMP "horizun-install-result-${{ github.run_id }}.txt"
-          $p = Start-Process $setup.FullName -ArgumentList '/SILENT','/SUPPRESSMSGBOXES','/NORESTART',"/HORIZUNRESULT=$result" -Wait -PassThru
+          # CI validates the installed artifact directly. It must never discover
+          # or rewrite a maintainer's personal Claude/Codex configuration on the
+          # self-hosted release runner.
+          $p = Start-Process $setup.FullName -ArgumentList '/SILENT','/SUPPRESSMSGBOXES','/NORESTART','/HORIZUNCLIENT=None',"/HORIZUNRESULT=$result" -Wait -PassThru
 
           # BOTH, and neither alone. Inno returns 0 from any install that
           # COMPLETES - including one where a year failed and was rolled back -
@@ -549,10 +637,16 @@ jobs:
       # commit, and is it the one in the tree".
       - name: Verify one clean commit from source to what is installed
         shell: pwsh
-        # Unsigned is explicit because no public CA identity exists yet; see the
-        # release policy. The result path is the exact per-run file requested in
-        # the install step, never the global result left by an earlier install.
-        run: pwsh scripts/verify-release.ps1 -Installed -AllowUnsigned -InstallResult "$env:RUNNER_TEMP/horizun-install-result-${{ github.run_id }}.txt" -Json artifacts/live/release-chain.json
+        # Branch builds keep the explicit unsigned exception so the installer can
+        # be tested before certificate provisioning. A stable tag has no exception.
+        # The result path is the exact per-run file requested in the install step,
+        # never the global result left by an earlier install.
+        run: |
+          if ('${{ startsWith(github.ref, 'refs/tags/v') }}' -eq 'true') {
+            pwsh scripts/verify-release.ps1 -Installed -InstallResult "$env:RUNNER_TEMP/horizun-install-result-${{ github.run_id }}.txt" -Json artifacts/live/release-chain.json
+          } else {
+            pwsh scripts/verify-release.ps1 -Installed -AllowUnsigned -InstallResult "$env:RUNNER_TEMP/horizun-install-result-${{ github.run_id }}.txt" -Json artifacts/live/release-chain.json
+          }
 
       - name: Publish the installed release-chain evidence
         uses: actions/upload-artifact@v4
@@ -643,7 +737,7 @@ jobs:
 
   publish-stable-release:
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'HorizunGroup/horizun-revit-mcp'
-    needs: [package, stable-release-evidence]
+    needs: [package, public-signature, stable-release-evidence]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
           $srvSha = (Get-FileHash "$stage/$($doc.Server.File)" -Algorithm SHA256).Hash.ToLower()
           if ($srvSha -ne $doc.Server.Sha256) { throw "server: manifest says $($doc.Server.Sha256), file is $srvSha" }
           if ($doc.Server.Sha256.Length -ne 64) { throw "the server hash is truncated - a prefix identifies nothing" }
-          foreach ($helper in 'register-client.ps1','verify-clients.ps1','verify-install.ps1','complete-install.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
+          foreach ($helper in 'register-client.ps1','verify-clients.ps1','verify-install.ps1','complete-install.ps1','stop-installed-server.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
             if (-not (Test-Path "$stage/server/client-tools/$helper")) {
               throw "installer client helper is missing: $helper"
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,14 @@ Do not retype it with `%LOCALAPPDATA%`: `cmd.exe` expands that variable and
 **PowerShell does not**, so a config written that way points somewhere that does
 not exist and the client shows no tools without saying why.
 
-Installation and registration are two phases. Do not rewrite the configuration
-of the Claude/Codex process that is currently running: it may overwrite the edit
-when it exits. Install and verify first, print the command below, ask the user to
-close the client, run it from a fresh shell, then reopen the client.
+Installation and registration are two internal phases but one user action. Do not
+rewrite the configuration of the Claude/Codex process that is currently running:
+it may overwrite the edit when it exits. The installer runs
+`complete-install.ps1`, which waits for active clients to close, registers beside
+existing MCP entries, verifies the configuration, and completes
+`horizun_health` after Revit's first start. Report the durable state from
+`%LOCALAPPDATA%\Horizun\install-status.json`. The commands below are manual
+recovery only.
 
 ```powershell
 # Claude Code — user scope makes it available across projects
@@ -254,10 +258,14 @@ máquina. No la reescribas con `%LOCALAPPDATA%`: `cmd.exe` expande esa variable 
 **PowerShell no**, así que una config escrita así apunta a un sitio que no
 existe y el cliente no muestra herramientas sin decir por qué.
 
-La instalación y el registro son dos fases. No reescribas la configuración del
-proceso de Claude/Codex que está corriendo: puede pisar el cambio al cerrarse.
-Instala y verifica, imprime el comando siguiente, pide cerrar el cliente,
-ejecutarlo desde una consola nueva y después volver a abrir el cliente.
+La instalación y el registro son dos fases internas pero una sola acción del
+usuario. No reescribas la configuración del proceso de Claude/Codex que está
+corriendo: puede pisar el cambio al cerrarse. El instalador ejecuta
+`complete-install.ps1`, que espera a que cierren los clientes activos, registra
+sin eliminar otros MCP, verifica la configuración y completa `horizun_health`
+después del primer arranque de Revit. Reporta el estado durable de
+`%LOCALAPPDATA%\Horizun\install-status.json`. Los comandos siguientes quedan
+solo como recuperación manual.
 
 ```powershell
 # Claude Code — el scope user lo deja disponible en todos los proyectos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 What changed, and — where it matters — what was actually measured rather than
 assumed. Dates are the day the work landed.
 
-## v0.9.0 — 2026-08-14
+## v0.9.0 — 2026-08-15
+
+- **Public release trust state.** By owner decision, 0.9.0 ships without a
+  publicly trusted Authenticode identity while the SignPath Foundation
+  application is reviewed. The installer, manifest, SBOM, SHA-256 checksums,
+  provenance and Revit 2023–2027 live matrix remain mandatory. Windows/Revit may
+  show an unknown-publisher warning. Starting with 1.0.0, the clean-runner public
+  signature and timestamp gate is mandatory and has no unsigned exception.
 
 - **Release hardening: protocol, durability, installation and public supply chain.**
   JSON-RPC now enforces the MCP initialization lifecycle and request-id rules; the

--- a/CODE-SIGNING-POLICY.md
+++ b/CODE-SIGNING-POLICY.md
@@ -1,0 +1,86 @@
+# Code signing policy
+
+Horizun Revit MCP is free and open-source software released under Apache-2.0.
+Stable Windows releases are intended to use **free code signing provided by
+[SignPath.io](https://signpath.io/), certificate by
+[SignPath Foundation](https://signpath.org/)**.
+
+## Current status
+
+The SignPath Foundation application is pending. This policy does not claim that
+an existing artifact is signed. The latest public release predates the
+application and its download page identifies it as unsigned. A release may only
+claim SignPath signing after the public signature gate has verified the exact
+published bytes on a clean Windows runner.
+
+## Scope
+
+The signing project may sign only release artifacts built from
+[`HorizunGroup/horizun-revit-mcp`](https://github.com/HorizunGroup/horizun-revit-mcp):
+
+- the Horizun MCP server executable and its own assembly;
+- the Horizun Revit add-in assembly compiled for Revit 2023 through 2027; and
+- the installer that contains those binaries and their open-source runtime
+  dependencies.
+
+Autodesk Revit and its API assemblies are system dependencies. They are not
+distributed or signed by this project. Third-party open-source binaries included
+in the installer retain their own publisher and license identity and are not
+re-signed as Horizun binaries.
+
+## Build and release controls
+
+- Source, build scripts and GitHub Actions workflows are public and versioned in
+  the same repository.
+- Release signing starts only from a protected `v*` tag whose version matches the
+  product version in source.
+- The unsigned signing input must be built on GitHub-hosted runners from the
+  tagged commit. The separate self-hosted Revit runner may consume and test the
+  signed package, but it is not an origin for SignPath signing input.
+- SignPath origin verification binds each request to the repository, workflow,
+  commit and GitHub artifact.
+- Every stable release requires a human signing approval and a complete live
+  verification matrix for Revit 2023 through 2027.
+- CI generates a CycloneDX SBOM, full SHA-256 manifest, release checksums and
+  GitHub build-provenance attestations.
+- A disposable GitHub-hosted Windows runner verifies Authenticode public trust,
+  trusted timestamps and the absence of self-signed own binaries before
+  publication.
+- A failed signature, timestamp, install, rollback or live test blocks release.
+  There is no unsigned exception for a stable tag.
+
+The detailed mechanical gates are documented in
+[`docs/RELEASE-POLICY.md`](docs/RELEASE-POLICY.md).
+
+## Team roles
+
+The Horizun Group organization owners are publicly accountable for this policy:
+
+- **Committers and reviewers:**
+  [`@pablo-horizun`](https://github.com/pablo-horizun),
+  [`@isabela-horizun`](https://github.com/isabela-horizun), and
+  [`@daniela-horizun`](https://github.com/daniela-horizun).
+- **Signing approvers:** the same organization owners. A stable signing request
+  requires approval by an owner who has reviewed the release evidence.
+
+All maintainers must use multi-factor authentication for GitHub and SignPath.
+Signing configuration and workflow files are covered by repository CODEOWNERS.
+
+## Privacy and system changes
+
+Horizun does not collect analytics or transmit model data automatically. Network
+operations happen only when the user explicitly requests them. The complete
+policy is in [`docs/PRIVACY.md`](docs/PRIVACY.md).
+
+The installer announces the paths, client configuration, scheduled completion
+and uninstall behavior it changes. It never installs private trust roots for a
+public release. Local self-signed development certificates are outside the
+public release path and are created only by an explicit developer command.
+
+## Reporting and revocation
+
+Report a suspected signing-policy violation or compromised release privately as
+described in [`SECURITY.md`](SECURITY.md). Maintainers will suspend publication,
+preserve the affected evidence and work with SignPath Foundation to revoke the
+signature or certificate when warranted.
+

--- a/CODE-SIGNING-POLICY.md
+++ b/CODE-SIGNING-POLICY.md
@@ -1,17 +1,18 @@
 # Code signing policy
 
 Horizun Revit MCP is free and open-source software released under Apache-2.0.
-Stable Windows releases are intended to use **free code signing provided by
+Windows releases from 1.0.0 onward must use **free code signing provided by
 [SignPath.io](https://signpath.io/), certificate by
 [SignPath Foundation](https://signpath.org/)**.
 
 ## Current status
 
 The SignPath Foundation application was submitted on 2026-08-15 and is awaiting
-review. This policy does not claim that an existing artifact is signed. The
-latest public release predates the application and its download page identifies
-it as unsigned. A release may only claim SignPath signing after the public
+review. Horizun 0.9.0 is intentionally released unsigned and its download page
+must identify it that way. Windows and Revit may therefore display an unknown
+publisher warning. A release may only claim SignPath signing after the public
 signature gate has verified the exact published bytes on a clean Windows runner.
+Version 1.0.0 and every later release is blocked unless that gate passes.
 
 ## Scope
 
@@ -39,15 +40,18 @@ re-signed as Horizun binaries.
   signed package, but it is not an origin for SignPath signing input.
 - SignPath origin verification binds each request to the repository, workflow,
   commit and GitHub artifact.
-- Every stable release requires a human signing approval and a complete live
-  verification matrix for Revit 2023 through 2027.
+- Every release requires a complete live verification matrix for Revit 2023
+  through 2027. Releases from 1.0.0 onward additionally require human signing
+  approval.
 - CI generates a CycloneDX SBOM, full SHA-256 manifest, release checksums and
   GitHub build-provenance attestations.
 - A disposable GitHub-hosted Windows runner verifies Authenticode public trust,
   trusted timestamps and the absence of self-signed own binaries before
   publication.
-- A failed signature, timestamp, install, rollback or live test blocks release.
-  There is no unsigned exception for a stable tag.
+- A failed install, rollback or live test blocks every release. From 1.0.0 onward,
+  a failed or missing signature or timestamp also blocks release and there is no
+  unsigned exception. The only temporary exception is a correctly disclosed 0.x
+  artifact whose own binaries are all verified as unsigned on a clean runner.
 
 The detailed mechanical gates are documented in
 [`docs/RELEASE-POLICY.md`](docs/RELEASE-POLICY.md).

--- a/CODE-SIGNING-POLICY.md
+++ b/CODE-SIGNING-POLICY.md
@@ -7,11 +7,11 @@ Stable Windows releases are intended to use **free code signing provided by
 
 ## Current status
 
-The SignPath Foundation application is pending. This policy does not claim that
-an existing artifact is signed. The latest public release predates the
-application and its download page identifies it as unsigned. A release may only
-claim SignPath signing after the public signature gate has verified the exact
-published bytes on a clean Windows runner.
+The SignPath Foundation application was submitted on 2026-08-15 and is awaiting
+review. This policy does not claim that an existing artifact is signed. The
+latest public release predates the application and its download page identifies
+it as unsigned. A release may only claim SignPath signing after the public
+signature gate has verified the exact published bytes on a clean Windows runner.
 
 ## Scope
 
@@ -83,4 +83,3 @@ Report a suspected signing-policy violation or compromised release privately as
 described in [`SECURITY.md`](SECURITY.md). Maintainers will suspend publication,
 preserve the affected evidence and work with SignPath Foundation to revoke the
 signature or certificate when warranted.
-

--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ deploys a different add-in binary compiled against each installed year's own API
 It also installs the MCP server and reports exactly which years succeeded. No Git
 or .NET SDK is required for this path.
 
-The release carries `SHA256SUMS.txt` and a complete payload manifest. The current
-build is not signed by a publicly trusted code-signing CA, so Windows/Revit may
-show a publisher warning; verify the SHA-256 before running it.
+The release carries `SHA256SUMS.txt` and a complete payload manifest. The latest
+public release predates the pending SignPath Foundation application and is not
+signed by a publicly trusted code-signing CA, so Windows/Revit may show a
+publisher warning; verify the SHA-256 before running it. Future stable releases
+must satisfy the public signature gate in the
+[code signing policy](CODE-SIGNING-POLICY.md) before publication. The intended
+open-source service is: **Free code signing provided by SignPath.io, certificate
+by SignPath Foundation.** This is an application status, not a claim that the
+current download is already signed.
 
 The setup installs every supported Revit payload present in the release and the
 MCP server. It also completes Codex/Claude registration automatically. If either
@@ -369,6 +375,11 @@ outbound HTTPS calls only to fixed Microsoft Entra and `api.powerbi.com`
 endpoints; it accepts no URL or credential in tool arguments. The full threat model — what is defended, and what
 deliberately is not — is in [docs/security-model.md](docs/security-model.md),
 and it is written to be argued with.
+
+Horizun has no automatic telemetry or maintainer-operated data collection.
+User-requested network operations and local state are described in the
+[privacy policy](docs/PRIVACY.md). Stable Windows release signing is governed by
+the [code signing policy](CODE-SIGNING-POLICY.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,15 @@ It also installs the MCP server and reports exactly which years succeeded. No Gi
 or .NET SDK is required for this path.
 
 The release carries `SHA256SUMS.txt` and a complete payload manifest. The latest
-public release predates the pending SignPath Foundation application and is not
-signed by a publicly trusted code-signing CA, so Windows/Revit may show a
+public release predates the SignPath Foundation application submitted on
+2026-08-15 and is not signed by a publicly trusted code-signing CA, so
+Windows/Revit may show a
 publisher warning; verify the SHA-256 before running it. Future stable releases
 must satisfy the public signature gate in the
 [code signing policy](CODE-SIGNING-POLICY.md) before publication. The intended
 open-source service is: **Free code signing provided by SignPath.io, certificate
-by SignPath Foundation.** This is an application status, not a claim that the
-current download is already signed.
+by SignPath Foundation.** The application is awaiting review; this is not a
+claim that the current download is already signed.
 
 The setup installs every supported Revit payload present in the release and the
 MCP server. It also completes Codex/Claude registration automatically. If either

--- a/README.md
+++ b/README.md
@@ -35,13 +35,11 @@ deploys a different add-in binary compiled against each installed year's own API
 It also installs the MCP server and reports exactly which years succeeded. No Git
 or .NET SDK is required for this path.
 
-The release carries `SHA256SUMS.txt` and a complete payload manifest. The latest
-public release predates the SignPath Foundation application submitted on
-2026-08-15 and is not signed by a publicly trusted code-signing CA, so
-Windows/Revit may show a
-publisher warning; verify the SHA-256 before running it. Future stable releases
-must satisfy the public signature gate in the
-[code signing policy](CODE-SIGNING-POLICY.md) before publication. The intended
+The release carries `SHA256SUMS.txt` and a complete payload manifest. Horizun
+0.9.0 is intentionally distributed without a publicly trusted code-signing CA,
+so Windows/Revit may show a publisher warning; verify the SHA-256 before running
+it. Public signing becomes a mandatory release gate at 1.0.0 under the
+[code signing policy](CODE-SIGNING-POLICY.md). The intended
 open-source service is: **Free code signing provided by SignPath.io, certificate
 by SignPath Foundation.** The application is awaiting review; this is not a
 claim that the current download is already signed.

--- a/README.md
+++ b/README.md
@@ -40,25 +40,28 @@ build is not signed by a publicly trusted code-signing CA, so Windows/Revit may
 show a publisher warning; verify the SHA-256 before running it.
 
 The setup installs every supported Revit payload present in the release and the
-MCP server. It also installs Start-menu helpers to register or verify Horizun in
-Codex and Claude. Registration is explicit and unchecked by default: the helper
-makes timestamped backups, preserves all other MCP entries and refuses to edit a
-client that is still running and could overwrite its configuration. An advanced
-pre-uninstall helper can remove only the `horizun-revit` client entries and,
-only when explicitly selected, purge local state or the self-signing trust.
+MCP server. It also completes Codex/Claude registration automatically. If either
+client is open, it does **not** edit underneath it: a user-level helper waits for
+the client to close, makes timestamped backups, preserves every other MCP entry,
+registers Horizun, verifies the configuration and completes `horizun_health`
+after the first Revit start. Its durable status is
+`%LOCALAPPDATA%\Horizun\install-status.json`; Start-menu helpers can resume or
+inspect it. An advanced pre-uninstall helper can remove only the
+`horizun-revit` client entries and, only when explicitly selected, purge local
+state or self-signing trust.
 
-For a command-line installation without Git or an SDK, download the repository's
-small bootstrap and let it select the latest release. It downloads the setup and
-`SHA256SUMS.txt` from the same GitHub release, verifies the complete SHA-256, and
-only then launches the installer:
+For a command-line installation without Git or an SDK, paste **one command**.
+It selects the latest release, downloads the setup and `SHA256SUMS.txt` from that
+same GitHub release, verifies the complete SHA-256, installs quietly, and safely
+finishes or schedules client registration and first-start health verification:
 
 ```powershell
-$p = Join-Path $env:TEMP 'horizun-install-release.ps1'
-Invoke-WebRequest 'https://raw.githubusercontent.com/HorizunGroup/horizun-revit-mcp/main/install-release.ps1' -OutFile $p
-powershell -ExecutionPolicy Bypass -File $p
+irm https://raw.githubusercontent.com/HorizunGroup/horizun-revit-mcp/main/install-release.ps1 | iex
 ```
 
-Pass `-Version vX.Y.Z` to pin a specific release instead of following `latest`.
+Download the script first and pass `-Version vX.Y.Z` when a pinned release or
+`-Interactive` Setup wizard is required. Quiet, latest and automatic client
+completion are the defaults.
 
 ### Build from source
 
@@ -78,8 +81,8 @@ Paste this into **Claude Code** or **Codex**, in any folder:
 ```
 Clone https://github.com/HorizunGroup/horizun-revit-mcp into this folder, read its
 AGENTS.md, and follow the install procedure there. Install and verify the binaries,
-then print the exact registration command for my client. Do not edit the active
-client's configuration; tell me to close it and run that command in a fresh shell.
+then confirm the automatic completion status. Do not edit an active client's
+configuration; let the installed helper finish registration after that client exits.
 ```
 
 Both agents pick up [AGENTS.md](AGENTS.md) automatically once they are inside the
@@ -100,16 +103,17 @@ for each of those years and the MCP server, installs both, and reads every
 installed binary back to prove it landed. A build failure changes nothing; a
 failure after that rolls back and tells you the state you are in.
 
-**The installer prints the exact path to register — use that one.** It is
+Automatic completion normally handles registration. **If manual recovery is
+needed, use the exact path printed by the installer.** It is
 already expanded for your machine, which matters: `%LOCALAPPDATA%` is expanded
 by `cmd.exe` and **not** by PowerShell, so a config written with the variable
 silently points nowhere.
 
 ```powershell
-# Claude Code — persistent for this user, from a fresh shell after closing Claude
+# Manual fallback: persistent for this user, after closing Claude
 claude mcp add --scope user horizun-revit -- "C:\Users\<YOU>\AppData\Local\Programs\Horizun\MCP\server\horizun-mcp.exe"
 
-# Codex — from a fresh shell after closing Codex
+# Manual fallback: after closing Codex
 codex mcp add horizun-revit -- "C:\Users\<YOU>\AppData\Local\Programs\Horizun\MCP\server\horizun-mcp.exe"
 ```
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -11,11 +11,11 @@ Read [AGENTS.md](../AGENTS.md) first — it loads the project rules every sessio
 
 ## EPIC 0 — Publicly trusted installation *(reopened 2026-08-14)*
 
-The earlier decision not to acquire a public signing identity was superseded by
-the requirement that installation reach 100/100 before production. The software
-side now fails closed: a stable tag cannot be built or verified with an unsigned
-or self-signed payload. What remains in 0.1 is an external identity/procurement
-step, not a code bypass.
+The public signing identity remains required for 1.0.0. By owner decision,
+0.9.0 may ship with an explicit unsigned disclosure while the SignPath
+application is reviewed. The software side fails closed from 1.0 onward: those
+tags cannot be built or verified with an unsigned or self-signed payload. What
+remains in 0.1 is an external identity/procurement step, not a 1.0 code bypass.
 
 What was MEASURED on 2026-08-04, because it corrects an earlier wrong conclusion
 in this very file's history: Revit's "Always Load" trust is keyed to the **binary**,
@@ -31,10 +31,10 @@ That leaves exactly three honest options, and no fourth:
 
 | ID | Story | Size | Dep |
 |----|-------|------|-----|
-| 0.1 ⭐ | Acquire a publicly trusted Authenticode identity (OV certificate or an eligible managed signing service), provision its private key only on the release runner, and set `SIGNING_CERT_THUMBPRINT`. The tag pipeline signs payload + wrapper and refuses unsigned/self-signed stable releases | M | — |
+| 0.1 ⭐ | Acquire a publicly trusted Authenticode identity (OV certificate or an eligible managed signing service), provision its private key only on the release runner, and set `SIGNING_CERT_THUMBPRINT`. The tag pipeline signs payload + wrapper and refuses unsigned/self-signed releases from 1.0 onward | M | — |
 | 0.2 ⭐ | **Self-sign, free**: `New-SelfSignedCertificate` + `Set-AuthenticodeSignature` (both already on Windows), certificate into Trusted Publishers, DLLs signed at install. Ends the dialog **permanently on machines that trust that certificate** — which is the team's own machines. Trust moves to the certificate, so a rebuild no longer re-prompts | M | — |
 | 0.3 ◐ | **AUTOMATED HALF DONE 2026-08-04** — `install.ps1` now re-signs the fresh binaries automatically when this user's certificate already exists and is trusted (no new trust is ever minted as a side effect; without a cert it prints the one command and WHY it will not run it for you). The human failure this removes: every install re-armed the dialog because re-signing was a separate step people forgot. The practice half stands: on a daily-use machine, install releases, do not rebuild | S | 0.2 |
-| 0.4 | Verify 0.9.0 on a clean machine that has never trusted Horizun: installer publisher valid, no unknown-publisher warning, all Revit payloads validly signed, one-paste setup, deferred CLI registration, and first `horizun_health` green | S | 0.1 |
+| 0.4 | Before 1.0.0, verify on a clean machine that has never trusted Horizun: installer publisher valid, no unknown-publisher warning, all Revit payloads validly signed, one-paste setup, deferred CLI registration, and first `horizun_health` green | S | 0.1 |
 
 0.2 remains useful for source builds on controlled machines, but it cannot satisfy
 0.1 or the stable-release gate. A public identity exists so that a clean third-party
@@ -396,7 +396,7 @@ review's whole diagnosis came about.
 | 5.7 ◐ | **FAIL-CLOSED PIPELINE DONE 2026-08-14; identity pending (0.1).** Stable tags require `SIGNING_CERT_THUMBPRINT`, sign the own exe/dll payload before wrapping, sign the setup afterwards, recompute and verify the manifest, reject unsigned/self-signed files, and remove `-AllowUnsigned` from installed release verification. Preview branches remain buildable for testing. Procurement/provisioning of the public identity and clean-machine proof remain external | M | 0.1 |
 | 5.8 ✅ | **NEGOTIATION SLICE DONE 2026-08-04** (golden-tested; 2026-07-28 RC guarded by a failing test). Remaining: full adapter, SDK conformance, client matrix, execution.taskSupport. Isolate the protocol behind a `ProtocolAdapter` independent of the Revit domain: conformance tests against the official SDK and MCP Inspector, golden JSON-RPC request/response tests, explicit per-version negotiation, client compatibility matrix, schema deprecation policy. Add `execution.taskSupport`. Do this BEFORE adopting 2026-07-28, which is still RC | M | — |
 | 5.9 ✅ | **DONE 2026-08-04.** Public governance: issue templates (bug / proposal / compatibility) that demand Revit version+build+language, Horizun version, MCP client, tool, document kind, expected vs observed, sanitised logs. Discussions, public roadmap and milestones, labels, review SLA, a second maintainer with release rights, ADRs | S | — |
-| 5.10 ✅ | **DONE 2026-08-04** — `docs/RELEASE-POLICY.md`. Release channels and the road to 1.0: `stable` (signed + matrix approved), `preview`, `validation-only` (no new binaries). Publish SemVer policy, schema compatibility, deprecation window, config migration, back-version support, and an explicit definition of "production ready" | M | 5.5, 5.7 |
+| 5.10 ✅ | **DONE 2026-08-04; amended 2026-08-15** — `docs/RELEASE-POLICY.md`. Release channels and the road to 1.0: `stable` (0.x may be disclosed unsigned; 1.0+ signed; matrix approved), `preview`, `validation-only` (no new binaries). Publish SemVer policy, schema compatibility, deprecation window, config migration, back-version support, and an explicit definition of "production ready" | M | 5.5, 5.7 |
 
 ### What the review got right, verified in this tree
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -9,10 +9,13 @@ Read [AGENTS.md](../AGENTS.md) first — it loads the project rules every sessio
 
 ---
 
-## EPIC 0 — The unsigned-add-in dialog *(purchase dropped 2026-08-04)*
+## EPIC 0 — Publicly trusted installation *(reopened 2026-08-14)*
 
-**0.1 is dropped: no certificate is being bought.** That decision stands, and this
-epic is rewritten around it rather than left looking alive.
+The earlier decision not to acquire a public signing identity was superseded by
+the requirement that installation reach 100/100 before production. The software
+side now fails closed: a stable tag cannot be built or verified with an unsigned
+or self-signed payload. What remains in 0.1 is an external identity/procurement
+step, not a code bypass.
 
 What was MEASURED on 2026-08-04, because it corrects an earlier wrong conclusion
 in this very file's history: Revit's "Always Load" trust is keyed to the **binary**,
@@ -28,16 +31,16 @@ That leaves exactly three honest options, and no fourth:
 
 | ID | Story | Size | Dep |
 |----|-------|------|-----|
-| ~~0.1~~ | ~~Buy an OV cert and sign in CI~~ — **dropped by the owner** | — | — |
+| 0.1 ⭐ | Acquire a publicly trusted Authenticode identity (OV certificate or an eligible managed signing service), provision its private key only on the release runner, and set `SIGNING_CERT_THUMBPRINT`. The tag pipeline signs payload + wrapper and refuses unsigned/self-signed stable releases | M | — |
 | 0.2 ⭐ | **Self-sign, free**: `New-SelfSignedCertificate` + `Set-AuthenticodeSignature` (both already on Windows), certificate into Trusted Publishers, DLLs signed at install. Ends the dialog **permanently on machines that trust that certificate** — which is the team's own machines. Trust moves to the certificate, so a rebuild no longer re-prompts | M | — |
 | 0.3 ◐ | **AUTOMATED HALF DONE 2026-08-04** — `install.ps1` now re-signs the fresh binaries automatically when this user's certificate already exists and is trusted (no new trust is ever minted as a side effect; without a cert it prints the one command and WHY it will not run it for you). The human failure this removes: every install re-armed the dialog because re-signing was a separate step people forgot. The practice half stands: on a daily-use machine, install releases, do not rebuild | S | 0.2 |
-| 0.4 | *(only if 0.1 ever revives)* Verify on a CLEAN machine that the dialog is gone — a machine that already trusts the certificate proves nothing | S | 0.1 |
+| 0.4 | Verify 0.9.0 on a clean machine that has never trusted Horizun: installer publisher valid, no unknown-publisher warning, all Revit payloads validly signed, one-paste setup, deferred CLI registration, and first `horizun_health` green | S | 0.1 |
 
-0.2 is the recommendation and it is not the same thing as 0.1: a purchased
-certificate exists so that **other people's** machines trust the build without
-installing anything. Self-signing costs nothing and solves it for ours. Installing a
-certificate into Trusted Publishers means anything signed with it is trusted, so it
-is the operator's decision to make deliberately, not a script's to make quietly.
+0.2 remains useful for source builds on controlled machines, but it cannot satisfy
+0.1 or the stable-release gate. A public identity exists so that a clean third-party
+machine can validate the publisher without importing a Horizun root certificate.
+Installing a private certificate into Trusted Publishers remains an operator's
+deliberate decision, never a silent installer side effect.
 
 ## EPIC 1 — Verified commands from field knowledge *(widens the moat)*
 
@@ -390,7 +393,7 @@ review's whole diagnosis came about.
 | 5.4 | **Human approval inside Revit** (`approval_mode: revit_ui`) for delete/save/export/family-replace/`execute_python`: non-modal panel naming document, tool, change summary, element count, external destinations, irreversible effects. Plus a ribbon-driven temporary unlock for `execute_python` (10–15 min, active document only, revoked on close/switch, optionally script-hash scoped) | L | 5.1 |
 | 5.5 | **Live certification matrix 2023–2027** published per release: JUnit/HTML report, exact Revit build, fixture hashes, tools covered and not, time and peak memory, sanitised warning log. Dimensions: year × language × units × model kind (non-shared/local/central/detached) × links × size × discipline × outcome (commit/rollback/refusal/crash recovery). Needs public synthetic fixtures | L | 5.1 |
 | 5.6 | **Chunked long operations** with cooperative cancellation, per-turn UI budget (100–250 ms), phase + percentage progress, safe checkpoints between batches, `submit_job` mapped to native MCP tasks. Benchmarks published as *longest continuous UI block*, not just total duration | L | 5.1 |
-| 5.7 | **Sign the installer and binaries**: OV/EV Authenticode over exe/dll/installer/packaged scripts, timestamping, GitHub build attestations, signed SBOM and manifest, verification during install. Certificate trust stays an IT decision (Intune/GPO) — never installed silently | M | 0.1 |
+| 5.7 ◐ | **FAIL-CLOSED PIPELINE DONE 2026-08-14; identity pending (0.1).** Stable tags require `SIGNING_CERT_THUMBPRINT`, sign the own exe/dll payload before wrapping, sign the setup afterwards, recompute and verify the manifest, reject unsigned/self-signed files, and remove `-AllowUnsigned` from installed release verification. Preview branches remain buildable for testing. Procurement/provisioning of the public identity and clean-machine proof remain external | M | 0.1 |
 | 5.8 ✅ | **NEGOTIATION SLICE DONE 2026-08-04** (golden-tested; 2026-07-28 RC guarded by a failing test). Remaining: full adapter, SDK conformance, client matrix, execution.taskSupport. Isolate the protocol behind a `ProtocolAdapter` independent of the Revit domain: conformance tests against the official SDK and MCP Inspector, golden JSON-RPC request/response tests, explicit per-version negotiation, client compatibility matrix, schema deprecation policy. Add `execution.taskSupport`. Do this BEFORE adopting 2026-07-28, which is still RC | M | — |
 | 5.9 ✅ | **DONE 2026-08-04.** Public governance: issue templates (bug / proposal / compatibility) that demand Revit version+build+language, Horizun version, MCP client, tool, document kind, expected vs observed, sanitised logs. Discussions, public roadmap and milestones, labels, review SLA, a second maintainer with release rights, ADRs | S | — |
 | 5.10 ✅ | **DONE 2026-08-04** — `docs/RELEASE-POLICY.md`. Release channels and the road to 1.0: `stable` (signed + matrix approved), `preview`, `validation-only` (no new binaries). Publish SemVer policy, schema compatibility, deprecation window, config migration, back-version support, and an explicit definition of "production ready" | M | 5.5, 5.7 |

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -71,7 +71,7 @@ Revit concepts.
 | X4 | 5 | T/S; tenant L pending | Direct REST; tests prove bounds, one send on replay and fail-closed lost response. |
 | R1 | 5 | L/T/S | Bounded FIFO, fairness, capacity and cancellation harnesses. |
 | R2 | 5 | L/T/S | Append-only durable ledger shared by Revit and Power BI mutations. |
-| D1 | 4 | L/T/S | One setup, checksum, payload manifest, SBOM and verified-release bootstrap. Missing publicly trusted code signature keeps this below 5. |
+| D1 | 4 | L/T/S | One-paste setup, checksum, payload manifest, SBOM, safe deferred Claude/Codex registration, durable resume and first-live health verification. Stable tags now fail closed without public signing; the external signing identity and clean-machine proof are still missing. |
 | D2 | 5 | B/L | Five independently compiled payloads. |
 
 Current source-candidate total: **74/75**. The only structural point not earned
@@ -110,7 +110,7 @@ reply. This rule applies equally to Horizun.
 | Direct Power BI rows | Implemented with fixed endpoints and durable replay | Roadmap/in progress | Not established |
 | Loaded RFA compiler | Parameters/types/reference skeleton/sweeps/nested RFA/MEP connectors | Family capabilities require pinned case run | Family creation claim requires pinned case run |
 | System-family types | Dedicated verified operation, including host compound layers | Requires pinned case run | Requires pinned case run |
-| Installation | One setup; no Git/SDK; checksum/manifest/SBOM; guarded Codex/Claude registration | Bundled Windows installer, MCPB and source workflow | Source/pyRevit workflow |
+| Installation | One paste; no Git/SDK; checksum/manifest/SBOM; automatic safe post-exit Codex/Claude registration; durable first-Revit health verification | Bundled Windows installer, MCPB and source workflow | Source/pyRevit workflow |
 | Publicly trusted signing | No | Must be checked per asset | Must be checked per asset |
 
 This table does not say that an undocumented competitor feature is impossible;

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -52,4 +52,3 @@ returned only to the MCP client that invoked the operation.
 Security-sensitive reports should follow [`SECURITY.md`](../SECURITY.md).
 Ordinary privacy questions may be opened as a public repository issue when they
 contain no model data, credentials or personal information.
-

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,55 @@
+# Privacy policy
+
+Horizun Revit MCP is a local bridge between an MCP client selected by the user
+and Autodesk Revit running on the same Windows machine.
+
+## Data Horizun does not collect
+
+The project has no Horizun-operated telemetry, analytics, advertising, crash
+reporting or cloud backend. It does not automatically upload models, element
+data, prompts, credentials, file paths or usage statistics to Horizun Group or
+to the maintainers.
+
+Local operational state is stored under `%USERPROFILE%\.horizun\` and
+`%LOCALAPPDATA%\Horizun\`. This includes settings, discovery records, durable job
+and idempotency state, installation status and logs needed to diagnose the local
+bridge. The uninstall helper identifies which state is preserved and removes it
+only when the user explicitly selects that option.
+
+## User-requested network operations
+
+Horizun transfers information to another networked system only when the user or
+the person operating the MCP client specifically requests an operation that
+requires it:
+
+- The one-command release installer downloads the installer and checksum from
+  the project's public GitHub release.
+- `horizun_power_bi_push` sends only the rows and destination selected by the
+  user to Microsoft's Power BI API. Credentials are supplied in the local MCP
+  server environment and are not accepted as tool arguments or stored by
+  Horizun.
+- `horizun_execute_python` runs code supplied by the user on the local Revit UI
+  thread. Because that code may use Python networking libraries, its network
+  behavior is determined by the explicit script, not by an automatic Horizun
+  service.
+- A user's MCP client or language-model provider may transmit prompts, tool
+  arguments or returned model information according to that provider's own
+  configuration and privacy policy. Horizun does not select that provider and
+  does not receive a copy.
+
+All other bridge traffic uses local standard input/output and authenticated
+Windows named pipes.
+
+## Credentials and sensitive model data
+
+Credentials remain in user-controlled environment variables or client
+configuration. Users should not place secrets in tool arguments, scripts,
+screenshots, models or public issue reports. Model data is processed locally and
+returned only to the MCP client that invoked the operation.
+
+## Contact
+
+Security-sensitive reports should follow [`SECURITY.md`](../SECURITY.md).
+Ordinary privacy questions may be opened as a public repository issue when they
+contain no model data, credentials or personal information.
+

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -10,7 +10,7 @@ was right; the written rule was missing. This is the rule.
 
 | Channel | What it means | Has binaries | Can be `latest` |
 |---|---|---|---|
-| **stable** | Live matrix approved/published for every supported Revit year; security gates green; payload and installer signed by a publicly trusted publisher | yes | **yes** |
+| **stable** | Live matrix approved/published for every supported Revit year and security gates green. A disclosed 0.x release may be unsigned; 1.0+ requires a publicly trusted publisher | yes | **yes** |
 | **preview** | New behaviour, fixtures partial, live verification incomplete or single-machine | yes, marked pre-release | no |
 | **validation-only** | Tests, harness, docs or CI. **No new binaries.** | no | **never** |
 
@@ -33,14 +33,16 @@ platform controls are on.
 
 Signing and public trust are separate facts. A self-signed or privately trusted
 certificate can prove byte identity in a controlled environment but does not make
-Windows trust the publisher on a clean machine. Preview builds state whether the
-payload and wrapper are unsigned, self-signed, or publicly trusted. A **stable tag
-has no unsigned exception**: CI requires a publicly trusted, non-self-signed
-Authenticode identity, signs the staged Horizun binaries and the installer wrapper,
-timestamps them, re-validates public trust on a disposable Microsoft-hosted Windows
-runner, and verifies the installed bytes without `-AllowUnsigned`.
-Missing identity, signature, timestamp or trust fails publication before a release
-can become `latest`.
+Windows trust the publisher on a clean machine. Every release states whether the
+payload and wrapper are unsigned, self-signed, or publicly trusted. By owner
+decision, 0.9.0 may become `latest` while correctly disclosed as unsigned; its
+manifest, SBOM, SHA-256 checksums, provenance, installed-package verification and
+complete live matrix remain release gates. For **1.0.0 and later**, CI requires a
+publicly trusted, non-self-signed Authenticode identity, signs the staged Horizun
+binaries and installer wrapper, timestamps them, re-validates public trust on a
+disposable Microsoft-hosted Windows runner, and verifies the installed bytes
+without `-AllowUnsigned`. Missing identity, signature, timestamp or trust then
+fails publication.
 
 The preferred no-cost public identity is SignPath Foundation. Its governance,
 team roles, privacy statement and origin requirements are defined in the

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -42,6 +42,14 @@ runner, and verifies the installed bytes without `-AllowUnsigned`.
 Missing identity, signature, timestamp or trust fails publication before a release
 can become `latest`.
 
+The preferred no-cost public identity is SignPath Foundation. Its governance,
+team roles, privacy statement and origin requirements are defined in the
+repository [code signing policy](../CODE-SIGNING-POLICY.md). The application is
+pending; until it is accepted and the clean-runner public-signature job passes,
+no release may claim SignPath signing. The SignPath signing input must originate
+entirely on GitHub-hosted runners. Self-hosted Revit jobs validate the resulting
+signed package but cannot contribute binaries to that signing request.
+
 ## Versioning
 
 SemVer over the **tool contract**, not over the C#. What is public is the set of tool

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -44,9 +44,10 @@ can become `latest`.
 
 The preferred no-cost public identity is SignPath Foundation. Its governance,
 team roles, privacy statement and origin requirements are defined in the
-repository [code signing policy](../CODE-SIGNING-POLICY.md). The application is
-pending; until it is accepted and the clean-runner public-signature job passes,
-no release may claim SignPath signing. The SignPath signing input must originate
+repository [code signing policy](../CODE-SIGNING-POLICY.md). The application was
+submitted on 2026-08-15 and is awaiting review; until it is accepted and the
+clean-runner public-signature job passes, no release may claim SignPath signing.
+The SignPath signing input must originate
 entirely on GitHub-hosted runners. Self-hosted Revit jobs validate the resulting
 signed package but cannot contribute binaries to that signing request.
 

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -10,7 +10,7 @@ was right; the written rule was missing. This is the rule.
 
 | Channel | What it means | Has binaries | Can be `latest` |
 |---|---|---|---|
-| **stable** | Live matrix approved/published for every supported Revit year; security gates green; signing status stated exactly | yes | **yes** |
+| **stable** | Live matrix approved/published for every supported Revit year; security gates green; payload and installer signed by a publicly trusted publisher | yes | **yes** |
 | **preview** | New behaviour, fixtures partial, live verification incomplete or single-machine | yes, marked pre-release | no |
 | **validation-only** | Tests, harness, docs or CI. **No new binaries.** | no | **never** |
 
@@ -33,11 +33,14 @@ platform controls are on.
 
 Signing and public trust are separate facts. A self-signed or privately trusted
 certificate can prove byte identity in a controlled environment but does not make
-Windows trust the publisher on a clean machine. Every release states whether the
-payload and wrapper are unsigned, self-signed, or signed by a publicly trusted CA.
-Until a public trust chain exists, users can see publisher prompts and must verify
-the published SHA-256. Stable means *matrix-approved*; it never implies a trust
-chain that the release does not actually carry.
+Windows trust the publisher on a clean machine. Preview builds state whether the
+payload and wrapper are unsigned, self-signed, or publicly trusted. A **stable tag
+has no unsigned exception**: CI requires a publicly trusted, non-self-signed
+Authenticode identity, signs the staged Horizun binaries and the installer wrapper,
+timestamps them, re-validates public trust on a disposable Microsoft-hosted Windows
+runner, and verifies the installed bytes without `-AllowUnsigned`.
+Missing identity, signature, timestamp or trust fails publication before a release
+can become `latest`.
 
 ## Versioning
 
@@ -111,6 +114,9 @@ one is currently checkable rather than a matter of opinion:
       window written into the CHANGELOG.
 - [ ] Two maintainers with release rights.
 - [ ] GitHub secret scanning and push protection enabled on the public repository.
+- [ ] Payload and installer carry a timestamped, publicly trusted Authenticode
+      signature, and the stable tag pipeline verifies the installed signatures
+      without an unsigned exception.
 
 Until every box is ticked, this ships as 0.x and says so. A 1.0 that means "we
 think it is good now" is the claim this project exists not to make.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -286,8 +286,14 @@ nothing in this repository audits it.
 ## 8. Code signing and public trust
 
 The package pipeline reports the signature state; a release must never imply a
-public trust chain it does not carry. The source installer also supports an
-explicit, per-user self-signing workflow (`scripts/self-sign.ps1`):
+public trust chain it does not carry. Stable tags fail closed unless every own
+payload binary and the setup wrapper have a valid, non-self-signed Authenticode
+signature. The signing key is provisioned outside the repository on the release
+runner. Public trust and timestamps are then checked again on a clean Microsoft-
+hosted Windows runner, and installed release verification has no unsigned
+exception. The source
+installer also supports an explicit, per-user self-signing workflow
+(`scripts/self-sign.ps1`):
 
 - Revit raises `Security - Unsigned Add-In` on first load, per add-in per year.
   On this machine that has been answered once per year and does not recur:
@@ -306,9 +312,11 @@ explicit, per-user self-signing workflow (`scripts/self-sign.ps1`):
   separately; uninstall never removes either silently.
 
 A self-signed certificate is useful only on accounts that explicitly trust it; it
-does not establish publisher identity on a clean third-party machine. A publicly
-trusted code-signing CA remains a separate release-hardening decision. Until one
-is used, release notes say so and users verify the release SHA-256/attestation.
+does not establish publisher identity on a clean third-party machine. Until a
+public signing identity is provisioned, branches and previews may be tested with
+an explicit unsigned exception, but **0.9.0 may not be tagged stable or published**.
+SHA-256, manifest and attestations complement publisher identity; they do not
+replace it.
 
 ## 9. Known gaps, stated
 

--- a/install-release.ps1
+++ b/install-release.ps1
@@ -4,17 +4,31 @@
   SHA256SUMS.txt from the SAME release, then launch it. No Git or .NET SDK.
 
   Usage:
+    irm https://raw.githubusercontent.com/HorizunGroup/horizun-revit-mcp/main/install-release.ps1 | iex
     powershell -ExecutionPolicy Bypass -File .\install-release.ps1
     powershell -ExecutionPolicy Bypass -File .\install-release.ps1 -Version vX.Y.Z
+
+  The default is a quiet CLI install. It then registers Horizun immediately when
+  the selected client is closed, or schedules the registration safely after the
+  active client exits. Live verification completes automatically after Revit's
+  first start. Pass -Interactive only when the Setup wizard itself is wanted.
 #>
 [CmdletBinding()]
 param(
     [string]$Version = 'latest',
+    [ValidateSet('Auto', 'Claude', 'Codex', 'Both', 'None')]
+    [string]$Client = 'Auto',
     [switch]$KeepDownloadedFiles,
+    [switch]$Interactive,
+    # Retained for compatibility. Quiet is the 0.9+ default.
     [switch]$Silent,
-    [switch]$VerifyOnly
+    [switch]$VerifyOnly,
+    [switch]$NoClientCompletion,
+    [switch]$NoLiveVerification
 )
 $ErrorActionPreference = 'Stop'
+
+if ($Interactive -and $Silent) { throw '-Interactive and -Silent are mutually exclusive.' }
 
 # Kept in this file deliberately: the documented bootstrap downloads this ONE
 # script to a temp folder. A helper beside the repository copy would not exist
@@ -125,8 +139,13 @@ try {
     }
 
     $resultPath = Join-Path $temporary 'install-result.txt'
-    $arguments = @("/HORIZUNRESULT=$resultPath")
-    if ($Silent) { $arguments += '/SILENT'; $arguments += '/SUPPRESSMSGBOXES' }
+    $installerClient = if ($NoClientCompletion) { 'None' } else { $Client }
+    $arguments = @("/HORIZUNRESULT=$resultPath", "/HORIZUNCLIENT=$installerClient", '/NORESTART')
+    if ($NoLiveVerification) { $arguments += '/HORIZUNNOLIVE=-NoLiveWait' }
+    if (-not $Interactive) {
+        $arguments += '/VERYSILENT'
+        $arguments += '/SUPPRESSMSGBOXES'
+    }
     $startedLocal = Get-Date
     $process = Start-Process -FilePath $setupPath -ArgumentList $arguments -Wait -PassThru
     $finishedLocal = Get-Date
@@ -134,6 +153,60 @@ try {
     $installResult = Read-HorizunInstallResult -Path $resultPath -StartedLocal $startedLocal `
         -FinishedLocal $finishedLocal -ExpectedVersion $release.tag_name
     Write-Host ("[Horizun] setup completed successfully for Revit " + $installResult.succeeded + '.') -ForegroundColor Green
+
+    if (-not $NoClientCompletion -and $Client -ne 'None') {
+        $serverRoot = Join-Path $env:LOCALAPPDATA 'Programs\Horizun\MCP\server'
+        $complete = Join-Path $serverRoot 'client-tools\complete-install.ps1'
+        if (Test-Path -LiteralPath $complete -PathType Leaf) {
+            # The 0.9+ Setup itself launches the same finisher so double-clicking
+            # the EXE is as complete as using this bootstrap. Give it a moment to
+            # publish fresh durable state; only invoke it here for a package that
+            # installed the helper but did not launch it. Two concurrent writers
+            # are not a convenience feature.
+            $statusPath = Join-Path $env:LOCALAPPDATA 'Horizun\install-status.json'
+            $freshCompletion = $false
+            for ($attempt = 1; $attempt -le 20; $attempt++) {
+                if (Test-Path -LiteralPath $statusPath) {
+                    try {
+                        $status = Get-Content -LiteralPath $statusPath -Raw | ConvertFrom-Json
+                        $updated = [datetime]::Parse([string]$status.updated_utc).ToUniversalTime()
+                        if ($updated -ge $startedLocal.ToUniversalTime().AddSeconds(-2)) { $freshCompletion = $true; break }
+                    }
+                    catch { }
+                }
+                Start-Sleep -Milliseconds 250
+            }
+            $completionExit = 0
+            if (-not $freshCompletion) {
+                $completionArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $complete, '-Client', $Client)
+                if ($NoLiveVerification) { $completionArgs += '-NoLiveWait' }
+                & powershell @completionArgs
+                $completionExit = $LASTEXITCODE
+            }
+            if ($completionExit -eq 1) {
+                throw 'The release installed, but automatic client completion failed. Review %LOCALAPPDATA%\Horizun\install-status.json.'
+            }
+            elseif ($completionExit -eq 2) {
+                Write-Host '[Horizun] binaries are installed, but no Claude/Codex configuration exists yet.' -ForegroundColor Yellow
+                Write-Host '          Start the intended client once, close it, then use the Start-menu shortcut' -ForegroundColor Yellow
+                Write-Host '          "Completar y verificar instalación de Horizun".' -ForegroundColor Yellow
+            }
+            else {
+                Write-Host '[Horizun] client registration and first-start health verification are complete or safely scheduled.' -ForegroundColor Green
+                Write-Host ("          status: " + $statusPath) -ForegroundColor DarkGray
+            }
+        }
+        else {
+            # v0.8 and older releases predate the deferred completion helper. A
+            # current bootstrap may legitimately be used to pin one of them; do
+            # not claim automation that artifact cannot provide.
+            Write-Host "[Horizun] $($release.tag_name) predates automatic client completion." -ForegroundColor Yellow
+            Write-Host '          Close the client and register the installed server manually:' -ForegroundColor Yellow
+            $serverExe = Join-Path $serverRoot 'horizun-mcp.exe'
+            Write-Host "          claude mcp add --scope user horizun-revit -- `"$serverExe`""
+            Write-Host "          codex mcp add horizun-revit -- `"$serverExe`""
+        }
+    }
 }
 finally {
     if ($KeepDownloadedFiles) { Write-Host "Downloaded files kept at $temporary" -ForegroundColor DarkYellow }

--- a/install.ps1
+++ b/install.ps1
@@ -209,6 +209,11 @@ try {
         $serverStage = Join-Path $stagingRoot 'server'
         New-Item -ItemType Directory -Path $serverStage -Force | Out-Null
         Get-ChildItem $serverBin -File | ForEach-Object { Copy-Item $_.FullName $serverStage -Force }
+        $clientTools = Join-Path $serverStage 'client-tools'
+        New-Item -ItemType Directory -Path $clientTools -Force | Out-Null
+        foreach ($helper in 'register-client.ps1','verify-clients.ps1','verify-install.ps1','complete-install.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
+            Copy-Item (Join-Path $PSScriptRoot "scripts\$helper") $clientTools -Force
+        }
         Write-Host "    staged  server"
     }
 
@@ -306,6 +311,61 @@ try {
             Dll = (Join-Path $serverInstall 'horizun-mcp.dll')
             StagedDll = (Join-Path $serverStage 'horizun-mcp.dll')
         })
+
+        # Client helpers are a directory, while the server's transactional
+        # replacement above intentionally handles only top-level runtime files.
+        # Give the directory its own undo record so a failed source update cannot
+        # leave new registration logic beside an old server (or vice versa).
+        $installedClientTools = Join-Path $serverInstall 'client-tools'
+        $clientToolsBackup = Join-Path $stagingRoot 'backup-client-tools'
+        $hadClientTools = Test-Path -LiteralPath $installedClientTools
+        if ($hadClientTools) { Copy-Item $installedClientTools $clientToolsBackup -Recurse -Force }
+        $undo.Add([pscustomobject]@{
+            What = 'MCP client completion helpers'
+            Action = {
+                if (Test-Path -LiteralPath $installedClientTools) { Remove-Item $installedClientTools -Recurse -Force }
+                if ($hadClientTools) { Copy-Item $clientToolsBackup $installedClientTools -Recurse -Force }
+            }.GetNewClosure()
+        })
+        if (Test-Path -LiteralPath $installedClientTools) { Remove-Item $installedClientTools -Recurse -Force }
+        Copy-Item (Join-Path $serverStage 'client-tools') $installedClientTools -Recurse -Force
+
+        # Release Setup installs dist/stage/manifest.json. A source build needs
+        # the same on-disk identity contract, generated from the exact staged
+        # bytes in this run, so verify-install can prove server + selected Revit
+        # payloads without trusting the installer's exit code.
+        $installedManifest = Join-Path (Split-Path -Parent $serverInstall) 'manifest.json'
+        $manifestBackup = Join-Path $stagingRoot 'backup-installed-manifest.json'
+        $hadInstalledManifest = Test-Path -LiteralPath $installedManifest
+        if ($hadInstalledManifest) { Copy-Item $installedManifest $manifestBackup -Force }
+        $undo.Add([pscustomobject]@{
+            What = 'installed payload manifest'
+            Action = {
+                if ($hadInstalledManifest) { Copy-Item $manifestBackup $installedManifest -Force }
+                elseif (Test-Path -LiteralPath $installedManifest) { Remove-Item $installedManifest -Force }
+            }.GetNewClosure()
+        })
+        $pluginManifestRows = foreach ($y in $Years) {
+            $pluginDll = Join-Path $staged[$y] 'Horizun.Revit.dll'
+            [pscustomobject]@{ Year = [int]$y; Sha256 = Get-HorizunFileHash $pluginDll }
+        }
+        $sourceProvenance = Get-HorizunProvenance (Join-Path $serverStage 'horizun-mcp.dll')
+        $sourceManifest = [pscustomobject]@{
+            Schema = 2
+            Commit = $(if ($sourceProvenance) { $sourceProvenance.Sha } else { 'unknown' })
+            CleanTree = [bool]($sourceProvenance -and -not $sourceProvenance.Dirty)
+            BuiltUtc = (Get-Date).ToUniversalTime().ToString('o')
+            Config = $Config
+            SourceInstall = $true
+            Server = [pscustomobject]@{
+                File = 'server/horizun-mcp.exe'
+                Sha256 = Get-HorizunFileHash (Join-Path $serverStage 'horizun-mcp.exe')
+            }
+            Plugins = @($pluginManifestRows)
+        }
+        $manifestTemp = "$installedManifest.tmp-$([guid]::NewGuid().ToString('N'))"
+        $sourceManifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $manifestTemp -Encoding UTF8
+        Move-Item -LiteralPath $manifestTemp -Destination $installedManifest -Force
         Write-Host ("    server : {0}$(if ($firstInstall) { '  (first install)' })" -f $serverInstall)
     }
 
@@ -394,7 +454,8 @@ if ((Test-Path -LiteralPath $signScript) -and $haveCert) {
     Write-Host "          (creates a self-signed cert and trusts it for this user - a deliberate decision, so it is not done for you)" -ForegroundColor DarkYellow
 }
 Write-Host ""
-Write-Host "Add the MCP server to your client. The path below is THIS machine's, already" -ForegroundColor Cyan
+Write-Host "Manual recovery commands (automatic completion normally handles this)." -ForegroundColor Cyan
+Write-Host "The path below is THIS machine's, already" -ForegroundColor Cyan
 Write-Host "expanded - do not retype it with %LOCALAPPDATA%, which PowerShell does not expand." -ForegroundColor Cyan
 Write-Host ""
     Write-Host "  Claude Code:"
@@ -416,7 +477,7 @@ Write-Host "    args = []"
 Write-Host "    startup_timeout_sec = 120"
 Write-Host "    tool_timeout_sec = 600"
     Write-Host ""
-    Write-Host "Close Claude/Codex before registering, then reopen it. A running client can rewrite its config from memory." -ForegroundColor Yellow
+    Write-Host "For manual recovery, close Claude/Codex before registering, then reopen it." -ForegroundColor Yellow
 Write-Host "  Cursor, Cline, Windsurf, Claude Desktop and other MCP clients - in their"
 Write-Host "  JSON config (mcpServers), using the SAME path:"
 Write-Host "    { `"mcpServers`": { `"horizun-revit`": { `"command`": `"$($serverExe -replace '\\', '\\')`" } } }"
@@ -435,4 +496,21 @@ Write-Host "  * A 'Horizun Hub' ribbon tab appears once a document is open; its 
 Write-Host ""
 Write-Host "Verify the pairing from your MCP client: call horizun_health. Updating later is:"
 Write-Host "  git pull, close Revit, run install.ps1 again."
+
+# Installation and client registration cannot safely be one synchronous write
+# while the invoking Claude/Codex process is alive. The installed finisher makes
+# it one USER action instead: it registers immediately when possible, otherwise
+# waits for the active client to exit, verifies the config, then completes
+# horizun_health after Revit's first start.
+$completeInstall = Join-Path $serverInstall 'client-tools\complete-install.ps1'
+if (Test-Path -LiteralPath $completeInstall -PathType Leaf) {
+    Write-Host ""
+    Write-Host "[Horizun] completing client registration automatically." -ForegroundColor Cyan
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $completeInstall -Client Auto
+    if ($LASTEXITCODE -eq 1) {
+        Write-Host "[Horizun] automatic completion failed; binaries remain installed and verified." -ForegroundColor Red
+        Write-Host "          Review $env:LOCALAPPDATA\Horizun\install-status.json" -ForegroundColor Red
+        exit 1
+    }
+}
 exit 0

--- a/install.ps1
+++ b/install.ps1
@@ -211,7 +211,7 @@ try {
         Get-ChildItem $serverBin -File | ForEach-Object { Copy-Item $_.FullName $serverStage -Force }
         $clientTools = Join-Path $serverStage 'client-tools'
         New-Item -ItemType Directory -Path $clientTools -Force | Out-Null
-        foreach ($helper in 'register-client.ps1','verify-clients.ps1','verify-install.ps1','complete-install.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
+        foreach ($helper in 'register-client.ps1','verify-clients.ps1','verify-install.ps1','complete-install.ps1','stop-installed-server.ps1','hz-call.ps1','uninstall-cleanup.ps1') {
             Copy-Item (Join-Path $PSScriptRoot "scripts\$helper") $clientTools -Force
         }
         Write-Host "    staged  server"

--- a/installer/horizun-mcp.iss
+++ b/installer/horizun-mcp.iss
@@ -17,26 +17,20 @@
 ; FAILS is reported as failed and rolled back to whatever was there before.
 ;
 ; Nothing outside Horizun's own folders is touched: no other add-in is
-; modified, and no MCP client configuration is rewritten behind the user's
-; back — the final page shows the one command that registers it.
+; modified. Client registration is completed only while that client is closed;
+; otherwise a per-user helper records the pending work and waits safely.
 ;
 ; ---------------------------------------------------------------------------
-; NOT DONE HERE YET, and it is the piece that actually silences Revit's
-; security dialog:
+; RELEASE SIGNING AND REVIT TRUST:
 ;
 ;   Signing the DLL is NOT enough. A signed add-in from a publisher the machine
 ;   does not know still raises a dialog — it changes from the red "Unsigned
 ;   Add-In" to "Signed Add-In" with an Always Load button, shown once per
 ;   certificate per machine instead of per binary. To get NO dialog at all on a
-;   clean machine, the publisher's public certificate must be in the machine's
-;   Trusted Publishers store BEFORE Revit starts:
-;
-;       certutil.exe -addstore TrustedPublisher horizun.cer
-;
-;   That is a change to the machine's trust configuration. It belongs in this
-;   installer as an explicit, opt-in step the person installing agrees to — not
-;   as a silent side effect — and it cannot be written until there is a real
-;   certificate to test it with. Deliberately absent rather than written blind.
+;   clean machine, the release must carry a valid public Authenticode chain.
+;   Stable CI signs the five add-ins, server exe/dll and this wrapper, and then
+;   rechecks them on a clean hosted Windows runner. This installer never imports
+;   a private root certificate or weakens the machine's trust policy.
 ; ---------------------------------------------------------------------------
 ; ----------------------------------------------------------------------------
 
@@ -102,6 +96,12 @@ Name: "{group}\Horizun Hub"; Filename: "{#AppHubUrl}"
 Name: "{group}\Configurar Horizun en Codex y Claude"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
   Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\server\client-tools\register-client.ps1"" -Client Both -SkipMissingClients"; \
   WorkingDir: "{app}\server\client-tools"
+Name: "{group}\Completar y verificar instalación de Horizun"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\server\client-tools\complete-install.ps1"" -Client Auto"; \
+  WorkingDir: "{app}\server\client-tools"
+Name: "{group}\Estado de instalación de Horizun"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\server\client-tools\complete-install.ps1"" -StatusOnly"; \
+  WorkingDir: "{app}\server\client-tools"
 Name: "{group}\Verificar clientes MCP de Horizun"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
   Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\server\client-tools\verify-clients.ps1"""; \
   WorkingDir: "{app}\server\client-tools"
@@ -115,19 +115,25 @@ Name: "{group}\Limpieza avanzada antes de desinstalar"; Filename: "{sys}\Windows
 ; going to be installed by people who were told it is safe.
 Name: "openhub"; Description: "Ver Horizun Hub - las herramientas y flujos construidos sobre este puente"; \
   Flags: unchecked
-; Explicit and unchecked: client configuration belongs to the user. The helper
-; makes timestamped backups, preserves every other MCP entry and refuses to edit
-; a running Codex/Claude process because those clients can overwrite the file.
-Name: "registerclients"; Description: "Registrar Horizun en Codex y Claude (ciérrelos primero; conserva y respalda los otros MCP)"; \
-  Flags: unchecked
 
 [Run]
 Filename: "{#AppHubUrl}"; Description: "Abrir Horizun Hub"; \
   Flags: shellexec nowait postinstall skipifsilent; Tasks: openhub
+; Complete the client side automatically. If Codex or Claude is open, the helper
+; records the pending work and waits outside Setup; it never writes under a live
+; client. It also verifies the installed manifest and finishes horizun_health
+; after the first Revit start. The process is hidden because every durable result
+; is written to %LOCALAPPDATA%\Horizun\install-status.json.
 Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
-  Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\server\client-tools\register-client.ps1"" -Client Both -SkipMissingClients"; \
-  Description: "Registrar Horizun en Codex y Claude"; WorkingDir: "{app}\server\client-tools"; \
-  Flags: postinstall skipifsilent waituntilterminated; Tasks: registerclients
+  Parameters: "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File ""{app}\server\client-tools\complete-install.ps1"" -Client {param:HORIZUNCLIENT|Auto} {param:HORIZUNNOLIVE|}"; \
+  WorkingDir: "{app}\server\client-tools"; Flags: runhidden nowait; Check: ShouldCompleteInstall
+
+[UninstallRun]
+; A pending first-start verification must not survive removal with a command that
+; points at files the uninstaller is about to delete.
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\server\client-tools\complete-install.ps1"" -CancelPending"; \
+  Flags: runhidden waituntilterminated skipifdoesntexist
 
 [Code]
 const
@@ -145,6 +151,11 @@ var
   ServerInstalled: Boolean;
   ServerFailure: String;
   UninstallFailures: String;
+
+function ShouldCompleteInstall(): Boolean;
+begin
+  Result := CompareText(ExpandConstant('{param:HORIZUNCLIENT|Auto}'), 'None') <> 0;
+end;
 
 procedure InitYears;
 begin

--- a/installer/horizun-mcp.iss
+++ b/installer/horizun-mcp.iss
@@ -87,8 +87,11 @@ Source: "..\dist\stage\plugin\2024\*"; DestDir: "{tmp}\HorizunPayload\plugin\202
 Source: "..\dist\stage\plugin\2025\*"; DestDir: "{tmp}\HorizunPayload\plugin\2025"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist deleteafterinstall
 Source: "..\dist\stage\plugin\2026\*"; DestDir: "{tmp}\HorizunPayload\plugin\2026"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist deleteafterinstall
 Source: "..\dist\stage\plugin\2027\*"; DestDir: "{tmp}\HorizunPayload\plugin\2027"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist deleteafterinstall
-Source: "..\dist\stage\manifest.json"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\dist\stage\Horizun.addin";  DestDir: "{app}";              Flags: ignoreversion
+; Identity and add-in manifests participate in the same post-install transaction
+; as the server and DLLs. Copying either directly to {app} before that transaction
+; completes can make a rolled-back install describe bytes that never landed.
+Source: "..\dist\stage\manifest.json"; DestDir: "{tmp}\HorizunPayload"; Flags: ignoreversion deleteafterinstall
+Source: "..\dist\stage\Horizun.addin"; DestDir: "{tmp}\HorizunPayload"; Flags: ignoreversion deleteafterinstall
 
 [Icons]
 Name: "{group}\Horizun Revit MCP (carpeta)"; Filename: "{app}"
@@ -151,6 +154,9 @@ var
   ServerInstalled: Boolean;
   ServerFailure: String;
   UninstallFailures: String;
+  YearDeployed: array[0..4] of Boolean;
+  YearManifestWritten: array[0..4] of Boolean;
+  InstallManifestWritten: Boolean;
 
 function ShouldCompleteInstall(): Boolean;
 begin
@@ -158,12 +164,20 @@ begin
 end;
 
 procedure InitYears;
+var
+  I: Integer;
 begin
   Years[0] := '2023';
   Years[1] := '2024';
   Years[2] := '2025';
   Years[3] := '2026';
   Years[4] := '2027';
+  for I := 0 to YearsCount - 1 do
+  begin
+    YearDeployed[I] := False;
+    YearManifestWritten[I] := False;
+  end;
+  InstallManifestWritten := False;
 end;
 
 { Revit holds a lock on the plugin it has loaded. Copying over it fails per-file and
@@ -317,7 +331,7 @@ begin
     ServerFailure := 'the server vanished after its swap; the previous one was restored';
     exit;
   end;
-  if DirExists(Backup) then DelTree(Backup, True, True, True);
+  { Keep Backup until every installed Revit year and both manifests succeed. }
   Result := True;
 end;
 
@@ -410,22 +424,119 @@ begin
     exit;
   end;
 
-  if not FileCopy(ExpandConstant('{app}') + '\Horizun.addin', AddinsDir(Year) + '\Horizun.addin', False) then
-  begin
-    { Without the manifest Revit never loads the DLL, so this is a failed install,
-      not a cosmetic problem. Roll the whole year back. }
-    DelTree(Dst, True, True, True);
-    if DirExists(Backup) then RenameFile(Backup, Dst);
-    FailedYears := FailedYears + Year + ' (the .addin manifest could not be written; the previous install was restored), ';
-    exit;
-  end;
-
-  { Only now is the previous version disposable, and only Horizun''s own folder. }
-  if DirExists(Backup) then DelTree(Backup, True, True, True);
+  { Keep Backup and defer the .addin manifest until the whole deployment is
+    known good. A server/add-in contract may never be partially promoted. }
 
   if InstalledYears <> '' then InstalledYears := InstalledYears + ', ';
   InstalledYears := InstalledYears + Year;
   Result := True;
+end;
+
+procedure RollbackDeployment;
+var
+  I: Integer;
+  Dst, Backup, Addin, AddinBackup, ServerDst, ServerBackup, ProductManifest, ProductManifestBackup: String;
+begin
+  for I := YearsCount - 1 downto 0 do
+  begin
+    Dst := AddinsDir(Years[I]) + '\Horizun';
+    Backup := AddinsDir(Years[I]) + '\Horizun.previous';
+    Addin := AddinsDir(Years[I]) + '\Horizun.addin';
+    AddinBackup := AddinsDir(Years[I]) + '\Horizun.addin.previous';
+    if YearManifestWritten[I] then
+    begin
+      if FileExists(AddinBackup) then
+      begin
+        DeleteFile(Addin);
+        RenameFile(AddinBackup, Addin);
+      end
+      else
+        DeleteFile(Addin);
+    end;
+    if YearDeployed[I] then
+    begin
+      if DirExists(Dst) then DelTree(Dst, True, True, True);
+      if DirExists(Backup) then RenameFile(Backup, Dst);
+    end;
+  end;
+
+  ProductManifest := ExpandConstant('{app}') + '\manifest.json';
+  ProductManifestBackup := ExpandConstant('{app}') + '\manifest.previous.json';
+  if InstallManifestWritten then
+  begin
+    DeleteFile(ProductManifest);
+    if FileExists(ProductManifestBackup) then RenameFile(ProductManifestBackup, ProductManifest);
+  end;
+
+  if ServerInstalled then
+  begin
+    ServerDst := ExpandConstant('{app}') + '\server';
+    ServerBackup := ExpandConstant('{app}') + '\server.previous';
+    if DirExists(ServerDst) then DelTree(ServerDst, True, True, True);
+    if DirExists(ServerBackup) then RenameFile(ServerBackup, ServerDst);
+  end;
+  ServerInstalled := False;
+  InstalledYears := '';
+end;
+
+function WriteDeploymentManifests: Boolean;
+var
+  I: Integer;
+  SourceAddin, Addin, AddinBackup, ProductManifest, ProductManifestBackup: String;
+begin
+  Result := False;
+  SourceAddin := ExpandConstant('{tmp}') + '\HorizunPayload\Horizun.addin';
+  for I := 0 to YearsCount - 1 do
+    if YearDeployed[I] then
+    begin
+      Addin := AddinsDir(Years[I]) + '\Horizun.addin';
+      AddinBackup := AddinsDir(Years[I]) + '\Horizun.addin.previous';
+      if FileExists(AddinBackup) then DeleteFile(AddinBackup);
+      if FileExists(Addin) and (not FileCopy(Addin, AddinBackup, False)) then
+      begin
+        FailedYears := FailedYears + Years[I] + ' (could not back up the existing .addin manifest), ';
+        exit;
+      end;
+      YearManifestWritten[I] := True;
+      if not FileCopy(SourceAddin, Addin, False) then
+      begin
+        FailedYears := FailedYears + Years[I] + ' (could not write the .addin manifest), ';
+        exit;
+      end;
+    end;
+
+  ProductManifest := ExpandConstant('{app}') + '\manifest.json';
+  ProductManifestBackup := ExpandConstant('{app}') + '\manifest.previous.json';
+  if FileExists(ProductManifestBackup) then DeleteFile(ProductManifestBackup);
+  if FileExists(ProductManifest) and (not FileCopy(ProductManifest, ProductManifestBackup, False)) then
+  begin
+    ServerFailure := 'the installed identity manifest could not be backed up';
+    exit;
+  end;
+  InstallManifestWritten := True;
+  if not FileCopy(ExpandConstant('{tmp}') + '\HorizunPayload\manifest.json', ProductManifest, False) then
+  begin
+    ServerFailure := 'the installed identity manifest could not be written';
+    exit;
+  end;
+  Result := True;
+end;
+
+procedure CommitDeployment;
+var
+  I: Integer;
+begin
+  if DirExists(ExpandConstant('{app}') + '\server.previous') then
+    DelTree(ExpandConstant('{app}') + '\server.previous', True, True, True);
+  if FileExists(ExpandConstant('{app}') + '\manifest.previous.json') then
+    DeleteFile(ExpandConstant('{app}') + '\manifest.previous.json');
+  for I := 0 to YearsCount - 1 do
+  begin
+    if DirExists(AddinsDir(Years[I]) + '\Horizun.previous') then
+      DelTree(AddinsDir(Years[I]) + '\Horizun.previous', True, True, True);
+    if FileExists(AddinsDir(Years[I]) + '\Horizun.addin.previous') then
+      DeleteFile(AddinsDir(Years[I]) + '\Horizun.addin.previous');
+  end;
 end;
 
 { Pascal Script has no BoolToStr and no ternary. }
@@ -450,9 +561,20 @@ begin
       if RevitInstalled(Years[I]) then
       begin
         FoundAny := True;
-        if ServerInstalled then DeployYear(Years[I])
+        if ServerInstalled then
+        begin
+          YearDeployed[I] := DeployYear(Years[I]);
+        end
         else FailedYears := FailedYears + Years[I] + ' (server deployment failed; add-in left unchanged), ';
       end;
+
+    if ServerInstalled and ((not FoundAny) or (FailedYears = '')) then
+    begin
+      if WriteDeploymentManifests then CommitDeployment
+      else RollbackDeployment;
+    end
+    else if ServerInstalled then
+      RollbackDeployment;
 
     { Old installers staged plugin payloads permanently under the application
       directory. It is not live; the new installer extracts to a private temp. }

--- a/installer/horizun-mcp.iss
+++ b/installer/horizun-mcp.iss
@@ -283,9 +283,26 @@ begin
   if (not FileExists(Staging + '\{#AppExeName}')) or (not FileExists(Staging + '\horizun-mcp.dll')) then
   begin DelTree(Staging, True, True, True); ServerFailure := 'the staged server is incomplete'; exit; end;
 
+  { Claude/Codex legitimately keeps the currently configured stdio server open.
+    Revit is already known to be closed, so no Revit-side command can be in
+    flight. Stop ONLY processes whose executable path is this exact installed
+    server; never stop the client and never use taskkill by image name. }
+  if DirExists(Dst) then
+  begin
+    if not Exec(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'),
+      '-NoProfile -ExecutionPolicy Bypass -File "' + Staging + '\client-tools\stop-installed-server.ps1"' +
+      ' -ServerPath "' + Dst + '\{#AppExeName}"',
+      '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      DelTree(Staging, True, True, True);
+      ServerFailure := 'the existing installed server could not be stopped safely';
+      exit;
+    end;
+  end;
+
   if DirExists(Dst) then
     if not RenameFile(Dst, Backup) then
-    begin DelTree(Staging, True, True, True); ServerFailure := 'the existing server is in use'; exit; end;
+    begin DelTree(Staging, True, True, True); ServerFailure := 'the existing server is still in use after the bounded stop'; exit; end;
   if not RenameFile(Staging, Dst) then
   begin
     if DirExists(Backup) then RenameFile(Backup, Dst);

--- a/publish/overlay/AGENTS.md
+++ b/publish/overlay/AGENTS.md
@@ -56,10 +56,14 @@ Do not retype it with `%LOCALAPPDATA%`: `cmd.exe` expands that variable and
 **PowerShell does not**, so a config written that way points somewhere that does
 not exist and the client shows no tools without saying why.
 
-Installation and registration are two phases. Do not edit the configuration of
-the Claude/Codex process that is currently running: it may overwrite the change
-when it exits. Install and verify first, print the command, ask the user to close
-the client, run it from a fresh shell, and reopen the client.
+Installation and registration are two internal phases but one user action. Do
+not edit the configuration of the Claude/Codex process that is currently
+running: it may overwrite the change when it exits. The installer runs
+`complete-install.ps1`, which waits for active clients to close, registers
+beside existing MCP entries, verifies the configuration and completes
+`horizun_health` after Revit's first start. Report the durable state from
+`%LOCALAPPDATA%\Horizun\install-status.json`. The commands below are manual
+recovery only.
 
 ```powershell
 # Claude Code — user scope is available across projects
@@ -202,10 +206,14 @@ máquina. No la reescribas con `%LOCALAPPDATA%`: `cmd.exe` expande esa variable 
 **PowerShell no**, así que una config escrita así apunta a un sitio que no
 existe y el cliente no muestra herramientas sin decir por qué.
 
-La instalación y el registro son dos fases. No edites la configuración del
-proceso de Claude/Codex que está corriendo: puede pisar el cambio al cerrarse.
-Instala y verifica, imprime el comando, pide cerrar el cliente, ejecutarlo desde
-una consola nueva y después volver a abrir el cliente.
+La instalación y el registro son dos fases internas pero una sola acción del
+usuario. No edites la configuración del proceso de Claude/Codex que está
+corriendo: puede pisar el cambio al cerrarse. El instalador ejecuta
+`complete-install.ps1`, que espera a que cierren los clientes activos, registra
+sin eliminar otros MCP, verifica la configuración y completa `horizun_health`
+después del primer arranque de Revit. Reporta el estado durable de
+`%LOCALAPPDATA%\Horizun\install-status.json`. Los comandos siguientes quedan
+solo como recuperación manual.
 
 ```powershell
 # Claude Code — el scope user queda disponible en todos los proyectos

--- a/publish/overlay/README.md
+++ b/publish/overlay/README.md
@@ -96,9 +96,8 @@ Paste one of these into the agent you already have open, in any folder:
 ```
 Clone https://github.com/HorizunGroup/horizun-revit-mcp into this folder, read its
 CLAUDE.md, and follow the install procedure there. Install and verify the binaries,
-then print the exact user-scope registration command. Do not edit the active
-Claude process's configuration; tell me to close it and run the command in a
-fresh shell.
+then confirm the automatic completion status. Do not edit the active Claude
+process's configuration; let the installed helper register after Claude exits.
 ```
 
 **Codex**
@@ -106,17 +105,17 @@ fresh shell.
 ```
 Clone https://github.com/HorizunGroup/horizun-revit-mcp into this folder, read its
 AGENTS.md, and follow the install procedure there. Install and verify the binaries,
-then print the exact registration command. Do not edit the active Codex process's
-configuration; tell me to close it and run the command in a fresh shell.
+then confirm the automatic completion status. Do not edit the active Codex
+process's configuration; let the installed helper register after Codex exits.
 ```
 
 Claude Code reads `CLAUDE.md` (which imports [AGENTS.md](AGENTS.md)); Codex reads
 [AGENTS.md](AGENTS.md) directly. Either way the agent checks the prerequisites,
 builds from this public source against each Revit version installed on the
 machine, installs the matching add-in binaries and MCP server, and verifies their
-commit and SHA-256. Registration is a deliberate second phase after the active
-client has closed; otherwise that client can overwrite its configuration on exit.
-Revit must be closed. No prebuilt executable is downloaded by this path.
+commit and SHA-256. Registration remains a safe internal second phase, but the
+helper completes it automatically after the active client closes. Revit must be
+closed. No prebuilt executable is downloaded by this path.
 
 ### Prebuilt release installer — optional
 
@@ -132,25 +131,28 @@ build is not signed by a publicly trusted code-signing CA, so Windows/Revit may
 show a publisher warning; verify the SHA-256 before running it.
 
 The setup installs every supported Revit payload present in the release and the
-MCP server. It also installs Start-menu helpers to register or verify Horizun in
-Codex and Claude. Registration is explicit and unchecked by default: the helper
-makes timestamped backups, preserves all other MCP entries and refuses to edit a
-client that is still running and could overwrite its configuration. An advanced
-pre-uninstall helper can remove only the `horizun-revit` client entries and,
-only when explicitly selected, purge local state or the self-signing trust.
+MCP server. It also completes Codex/Claude registration automatically. If either
+client is open, it does **not** edit underneath it: a user-level helper waits for
+the client to close, makes timestamped backups, preserves every other MCP entry,
+registers Horizun, verifies the configuration and completes `horizun_health`
+after the first Revit start. Its durable status is
+`%LOCALAPPDATA%\Horizun\install-status.json`; Start-menu helpers can resume or
+inspect it. An advanced pre-uninstall helper can remove only the
+`horizun-revit` client entries and, only when explicitly selected, purge local
+state or self-signing trust.
 
-For a command-line installation without Git or an SDK, download the repository's
-small bootstrap and let it select the latest release. It downloads the setup and
-`SHA256SUMS.txt` from the same GitHub release, verifies the complete SHA-256, and
-only then launches the installer:
+For a command-line installation without Git or an SDK, paste **one command**.
+It selects the latest release, downloads the setup and `SHA256SUMS.txt` from that
+same GitHub release, verifies the complete SHA-256, installs quietly, and safely
+finishes or schedules client registration and first-start health verification:
 
 ```powershell
-$p = Join-Path $env:TEMP 'horizun-install-release.ps1'
-Invoke-WebRequest 'https://raw.githubusercontent.com/HorizunGroup/horizun-revit-mcp/main/install-release.ps1' -OutFile $p
-powershell -ExecutionPolicy Bypass -File $p
+irm https://raw.githubusercontent.com/HorizunGroup/horizun-revit-mcp/main/install-release.ps1 | iex
 ```
 
-Pass `-Version vX.Y.Z` to pin a specific release instead of following `latest`.
+Download the script first and pass `-Version vX.Y.Z` when a pinned release or
+`-Interactive` Setup wizard is required. Quiet, latest and automatic client
+completion are the defaults.
 
 ### Build from source manually
 
@@ -174,16 +176,17 @@ for each of those years and the MCP server, installs both, and reads every
 installed binary back to prove it landed. A build failure changes nothing; a
 failure after that rolls back and tells you the state you are in.
 
-**The installer prints the exact path to register — use that one.** It is
+Automatic completion normally handles registration. **If manual recovery is
+needed, use the exact path printed by the installer.** It is
 already expanded for your machine, which matters: `%LOCALAPPDATA%` is expanded
 by `cmd.exe` and **not** by PowerShell, so a config written with the variable
 silently points nowhere.
 
 ```powershell
-# Claude Code — persistent for this user, from a fresh shell after closing Claude
+# Manual fallback: persistent for this user, after closing Claude
 claude mcp add --scope user horizun-revit -- "C:\Users\<YOU>\AppData\Local\Programs\Horizun\MCP\server\horizun-mcp.exe"
 
-# Codex — from a fresh shell after closing Codex
+# Manual fallback: after closing Codex
 codex mcp add horizun-revit -- "C:\Users\<YOU>\AppData\Local\Programs\Horizun\MCP\server\horizun-mcp.exe"
 ```
 

--- a/publish/overlay/README.md
+++ b/publish/overlay/README.md
@@ -126,9 +126,10 @@ deploys a different add-in binary compiled against each installed year's own API
 It also installs the MCP server and reports exactly which years succeeded. No Git
 or .NET SDK is required for this path.
 
-The release carries `SHA256SUMS.txt` and a complete payload manifest. The current
-build is not signed by a publicly trusted code-signing CA, so Windows/Revit may
-show a publisher warning; verify the SHA-256 before running it.
+The release carries `SHA256SUMS.txt` and a complete payload manifest. Horizun
+0.9.0 is intentionally distributed without a publicly trusted code-signing CA,
+so Windows/Revit may show a publisher warning; verify the SHA-256 before running
+it. Public signing becomes mandatory for 1.0.0 and later.
 
 The setup installs every supported Revit payload present in the release and the
 MCP server. It also completes Codex/Claude registration automatically. If either

--- a/scripts/complete-install.ps1
+++ b/scripts/complete-install.ps1
@@ -1,0 +1,310 @@
+#Requires -Version 5.1
+<#
+  Finish a Horizun installation without racing an active Claude or Codex.
+
+  If a requested client is open, this script records the pending work, installs
+  a CurrentUser resume entry, and starts a hidden helper. The helper waits for a
+  real quiet window, registers beside every existing MCP entry, verifies the
+  resulting configuration, then waits for the first Revit start and calls
+  horizun_health through the installed MCP server.
+
+  This is intentionally per-user and needs no administrator rights. The resume
+  entry is removed after live verification, by -CancelPending, or during
+  uninstall. Re-running the script is safe.
+
+  Exit codes: 0 completed or safely scheduled
+              1 failed
+              2 no supported client could be identified
+              3 still pending when a detached wait reached its deadline
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Auto', 'Claude', 'Codex', 'Both', 'None')]
+    [string]$Client = 'Auto',
+    [string]$Name = 'horizun-revit',
+    [string]$ServerPath,
+    [int]$WaitTimeoutMinutes = 1440,
+    [switch]$Detached,
+    [switch]$LiveOnly,
+    [switch]$NoLiveWait,
+    [switch]$NoResume,
+    [switch]$StatusOnly,
+    [switch]$CancelPending,
+    [string]$StatusPath,
+    # Deterministic harness hook. When supplied, each non-empty line names a
+    # client considered running; normal installs always inspect real processes.
+    [string]$ClientStateFile
+)
+$ErrorActionPreference = 'Stop'
+
+if ($WaitTimeoutMinutes -lt 1 -or $WaitTimeoutMinutes -gt 10080) {
+    throw 'WaitTimeoutMinutes must be between 1 and 10080 (seven days).'
+}
+if (-not $ServerPath) {
+    $ServerPath = Join-Path $env:LOCALAPPDATA 'Programs\Horizun\MCP\server\horizun-mcp.exe'
+}
+if (-not $StatusPath) {
+    $StatusPath = Join-Path $env:LOCALAPPDATA 'Horizun\install-status.json'
+}
+
+$register = Join-Path $PSScriptRoot 'register-client.ps1'
+$verify = Join-Path $PSScriptRoot 'verify-install.ps1'
+$runKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+$runName = 'HorizunMCPCompleteInstall'
+$powerShellExe = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+$verificationPath = "$StatusPath.verification.json"
+
+function Write-State([string]$State, [string]$Detail, [string]$ResolvedClient, $Extra) {
+    $dir = Split-Path -Parent $StatusPath
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $doc = [ordered]@{
+        schema = 1
+        updated_utc = (Get-Date).ToUniversalTime().ToString('o')
+        state = $State
+        detail = $Detail
+        client = $ResolvedClient
+        server_path = $ServerPath
+        verification_path = $verificationPath
+    }
+    if ($Extra) {
+        foreach ($property in $Extra.PSObject.Properties) { $doc[$property.Name] = $property.Value }
+    }
+    $tmp = "$StatusPath.tmp-$([guid]::NewGuid().ToString('N'))"
+    [pscustomobject]$doc | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $tmp -Encoding UTF8
+    Move-Item -LiteralPath $tmp -Destination $StatusPath -Force
+    Write-Host "[Horizun] $State - $Detail" -ForegroundColor $(if ($State -match 'failed') { 'Red' } elseif ($State -match 'waiting|awaiting|scheduled') { 'Yellow' } else { 'Green' })
+}
+
+function Resolve-Client([string]$Requested) {
+    if ($Requested -ne 'Auto') { return $Requested }
+    $claudeConfig = Join-Path $env:USERPROFILE '.claude.json'
+    $codexConfig = Join-Path $env:USERPROFILE '.codex\config.toml'
+    $hasClaude = Test-Path -LiteralPath $claudeConfig
+    $hasCodex = Test-Path -LiteralPath $codexConfig
+
+    # Preserve the caller's intent when the installer was launched by an agent.
+    # Both desktop apps may be open on a real workstation; waiting for an unrelated
+    # client would turn "one action" back into an unexplained permanent pending
+    # state. These variables are inherited by Setup and its completion helper.
+    $fromCodex = [bool]($env:CODEX_THREAD_ID -or $env:CODEX_CI -or $env:CODEX_INTERNAL_ORIGINATOR_OVERRIDE)
+    $fromClaude = [bool]($env:CLAUDECODE -or $env:CLAUDE_CODE_ENTRYPOINT -or $env:CLAUDE_CODE_SESSION)
+    if ($fromCodex -and -not $fromClaude -and ($hasCodex -or (Get-Command codex -ErrorAction SilentlyContinue))) { return 'Codex' }
+    if ($fromClaude -and -not $fromCodex -and ($hasClaude -or (Get-Command claude -ErrorAction SilentlyContinue))) { return 'Claude' }
+
+    if ($hasClaude -and $hasCodex) { return 'Both' }
+    if ($hasClaude) { return 'Claude' }
+    if ($hasCodex) { return 'Codex' }
+
+    # A first CLI start can put the executable on PATH before it creates a config.
+    # Name that situation rather than pretending registration succeeded. The
+    # registrar deliberately refuses to invent a whole client config from scratch.
+    $claudeCommand = Get-Command claude -ErrorAction SilentlyContinue
+    $codexCommand = Get-Command codex -ErrorAction SilentlyContinue
+    if ($claudeCommand -and $codexCommand) { return 'Both' }
+    if ($claudeCommand) { return 'Claude' }
+    if ($codexCommand) { return 'Codex' }
+    return 'None'
+}
+
+function Requested-Clients([string]$Resolved) {
+    if ($Resolved -eq 'Both') { return @('Claude', 'Codex') }
+    if ($Resolved -eq 'None') { return @() }
+    return @($Resolved)
+}
+
+function Client-IsRunning([string]$Which) {
+    if ($ClientStateFile) {
+        if (-not (Test-Path -LiteralPath $ClientStateFile)) { return $false }
+        return $Which -in @(Get-Content -LiteralPath $ClientStateFile | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    }
+    $pattern = if ($Which -eq 'Claude') { '(?i)^claude$' } else { '(?i)^(codex|openai\.codex)$' }
+    return @(Get-Process -ErrorAction SilentlyContinue | Where-Object ProcessName -match $pattern).Count -gt 0
+}
+
+function Running-Clients([string]$Resolved) {
+    return @(Requested-Clients $Resolved | Where-Object { Client-IsRunning $_ })
+}
+
+function Get-ResumeCommand([string]$Resolved) {
+    $quotedScript = '"' + $PSCommandPath.Replace('"', '""') + '"'
+    $quotedServer = '"' + $ServerPath.Replace('"', '""') + '"'
+    $quotedStatus = '"' + $StatusPath.Replace('"', '""') + '"'
+    $command = ('"{0}" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File {1} -Client {2} -ServerPath {3} -StatusPath {4} -WaitTimeoutMinutes {5} -Detached' -f `
+        $powerShellExe, $quotedScript, $Resolved, $quotedServer, $quotedStatus, $WaitTimeoutMinutes)
+    if ($NoLiveWait) { $command += ' -NoLiveWait' }
+    if ($ClientStateFile) { $command += ' -ClientStateFile "' + $ClientStateFile.Replace('"', '""') + '"' }
+    return $command
+}
+
+function Set-Resume([string]$Resolved) {
+    if ($NoResume) { return }
+    if (-not (Test-Path -LiteralPath $runKey)) { New-Item -Path $runKey -Force | Out-Null }
+    Set-ItemProperty -Path $runKey -Name $runName -Value (Get-ResumeCommand $Resolved) -Type String
+}
+
+function Clear-Resume {
+    if (Test-Path -LiteralPath $runKey) {
+        Remove-ItemProperty -Path $runKey -Name $runName -ErrorAction SilentlyContinue
+    }
+}
+
+function Start-DetachedWorker([string]$Resolved, [switch]$OnlyLive) {
+    $arguments = @(
+        '-NoProfile', '-WindowStyle', 'Hidden', '-ExecutionPolicy', 'Bypass',
+        '-File', ('"' + $PSCommandPath + '"'), '-Client', $Resolved,
+        '-ServerPath', ('"' + $ServerPath + '"'),
+        '-StatusPath', ('"' + $StatusPath + '"'),
+        '-WaitTimeoutMinutes', $WaitTimeoutMinutes, '-Detached'
+    )
+    if ($OnlyLive) { $arguments += '-LiveOnly' }
+    if ($NoResume) { $arguments += '-NoResume' }
+    if ($NoLiveWait) { $arguments += '-NoLiveWait' }
+    if ($ClientStateFile) { $arguments += '-ClientStateFile'; $arguments += ('"' + $ClientStateFile + '"') }
+    $stdout = "$StatusPath.worker.log"
+    $stderr = "$StatusPath.worker-error.log"
+    Start-Process -FilePath $powerShellExe -ArgumentList $arguments -WindowStyle Hidden `
+        -RedirectStandardOutput $stdout -RedirectStandardError $stderr | Out-Null
+}
+
+if ($StatusOnly) {
+    if (Test-Path -LiteralPath $StatusPath) { Get-Content -LiteralPath $StatusPath }
+    else { Write-Host "No Horizun completion status exists at $StatusPath" -ForegroundColor Yellow }
+    exit 0
+}
+
+if ($CancelPending) {
+    Clear-Resume
+    Remove-Item -LiteralPath $StatusPath, $verificationPath -Force -ErrorAction SilentlyContinue
+    Write-Host '[Horizun] pending installation completion was cancelled.' -ForegroundColor Yellow
+    exit 0
+}
+
+foreach ($needed in $register, $verify) {
+    if (-not (Test-Path -LiteralPath $needed -PathType Leaf)) { throw "Installed completion helper is missing: $needed" }
+}
+if (-not (Test-Path -LiteralPath $ServerPath -PathType Leaf)) { throw "Installed MCP server is missing: $ServerPath" }
+
+$resolved = Resolve-Client $Client
+if ($resolved -eq 'None' -and -not $LiveOnly) {
+    Write-State 'failed_no_client' 'Neither Claude nor Codex could be identified. Start the intended client once, close it, and run this helper again.' $resolved $null
+    exit 2
+}
+
+# Only one hidden finisher may own the pending work. An interactive invocation is
+# allowed to schedule that owner; detached duplicates simply leave it alone.
+$mutex = $null
+$mutexHeld = $false
+if ($Detached) {
+    $mutex = New-Object Threading.Mutex($false, 'Local\HorizunMCPCompleteInstall')
+    try { $mutexHeld = $mutex.WaitOne(0) } catch { $mutexHeld = $false }
+    if (-not $mutexHeld) {
+        Write-Host '[Horizun] another completion worker is already active.' -ForegroundColor DarkGray
+        exit 0
+    }
+}
+
+try {
+    Set-Resume $resolved
+    $deadline = (Get-Date).AddMinutes($WaitTimeoutMinutes)
+
+    if (-not $LiveOnly) {
+        $running = @(Running-Clients $resolved)
+        if ($running.Count -gt 0 -and -not $Detached) {
+            Write-State 'waiting_for_client_exit' ("Close " + ($running -join ' and ') + '; registration will finish automatically afterward.') $resolved `
+                ([pscustomobject]@{ running_clients = $running })
+            Start-DetachedWorker $resolved
+            exit 0
+        }
+
+        while ($running.Count -gt 0 -and (Get-Date) -lt $deadline) {
+            Write-State 'waiting_for_client_exit' ("Waiting for " + ($running -join ' and ') + ' to close; no configuration has been edited.') $resolved `
+                ([pscustomobject]@{ running_clients = $running })
+            Start-Sleep -Seconds 2
+            $running = @(Running-Clients $resolved)
+        }
+        if ($running.Count -gt 0) {
+            Write-State 'registration_pending' 'The client stayed open through the wait window. The user-level resume entry remains active.' $resolved `
+                ([pscustomobject]@{ running_clients = $running })
+            exit 3
+        }
+
+        # Require a short quiet window. This closes the close/reopen race: if the
+        # client comes back immediately, registration waits instead of writing
+        # underneath the new process.
+        Start-Sleep -Seconds 2
+        $running = @(Running-Clients $resolved)
+        if ($running.Count -gt 0) {
+            if (-not $Detached) { Start-DetachedWorker $resolved; exit 0 }
+            while ($running.Count -gt 0 -and (Get-Date) -lt $deadline) {
+                Start-Sleep -Seconds 2
+                $running = @(Running-Clients $resolved)
+            }
+        }
+
+        $registerJson = "$StatusPath.registration.json"
+        $arguments = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $register,
+            '-Client', $resolved, '-ServerPath', $ServerPath, '-Json', $registerJson)
+        if ($resolved -eq 'Both') { $arguments += '-SkipMissingClients' }
+        if ($ClientStateFile) { $arguments += '-Force' }
+        & $powerShellExe @arguments
+        if ($LASTEXITCODE -ne 0) {
+            Write-State 'registration_failed' "register-client.ps1 exited $LASTEXITCODE; existing client configuration was restored." $resolved $null
+            exit 1
+        }
+
+        & $powerShellExe -NoProfile -ExecutionPolicy Bypass -File $verify -Client $resolved `
+            -ServerPath $ServerPath -SkipLive -Json $verificationPath
+        if ($LASTEXITCODE -ne 0) {
+            Write-State 'verification_failed' "on-disk or client verification exited $LASTEXITCODE" $resolved $null
+            exit 1
+        }
+        Write-State 'installed_and_registered' 'Binaries and client configuration are verified. Restart the client; live health is the remaining automatic check.' $resolved $null
+    }
+
+    if ($NoLiveWait) {
+        Clear-Resume
+        Write-State 'installed_and_registered' 'Live verification was explicitly disabled.' $resolved $null
+        exit 0
+    }
+
+    & $powerShellExe -NoProfile -ExecutionPolicy Bypass -File $verify -Client $resolved `
+        -ServerPath $ServerPath -RequireLive -Json $verificationPath
+    if ($LASTEXITCODE -eq 0) {
+        $evidence = Get-Content -LiteralPath $verificationPath -Raw | ConvertFrom-Json
+        Clear-Resume
+        Write-State 'live_verified' 'horizun_health answered healthy through the installed server.' $resolved `
+            ([pscustomobject]@{ health = $evidence.health })
+        exit 0
+    }
+
+    if (-not $Detached) {
+        Write-State 'awaiting_revit' 'Start Revit once. Live verification will finish automatically in the background.' $resolved $null
+        Start-DetachedWorker $resolved -OnlyLive
+        exit 0
+    }
+
+    Write-State 'awaiting_revit' 'Waiting for the first Revit start so horizun_health can be verified.' $resolved $null
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 5
+        & $powerShellExe -NoProfile -ExecutionPolicy Bypass -File $verify -Client $resolved `
+            -ServerPath $ServerPath -RequireLive -Json $verificationPath *> $null
+        if ($LASTEXITCODE -eq 0) {
+            $evidence = Get-Content -LiteralPath $verificationPath -Raw | ConvertFrom-Json
+            Clear-Resume
+            Write-State 'live_verified' 'horizun_health answered healthy through the installed server.' $resolved `
+                ([pscustomobject]@{ health = $evidence.health })
+            exit 0
+        }
+    }
+
+    Write-State 'awaiting_revit' 'Revit was not available during this wait window. The user-level resume entry remains active.' $resolved $null
+    exit 3
+}
+catch {
+    Write-State 'completion_failed' $_.Exception.Message $resolved $null
+    exit 1
+}
+finally {
+    if ($mutexHeld) { try { $mutex.ReleaseMutex() } catch { } }
+    if ($mutex) { $mutex.Dispose() }
+}

--- a/scripts/install-completion.tests.ps1
+++ b/scripts/install-completion.tests.ps1
@@ -128,6 +128,13 @@ args = []
         -Client Codex -ServerPath $server -SkipLive *> $null
     Assert 'standalone Codex installation verification passes' ($LASTEXITCODE -eq 0) "exit $LASTEXITCODE"
 
+    $noneReport = Join-Path $root 'none-verification.json'
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'verify-install.ps1') `
+        -Client None -ServerPath $server -SkipLive -Json $noneReport *> $null
+    $noneState = Get-Content -LiteralPath $noneReport -Raw | ConvertFrom-Json
+    Assert 'binary-only verification does not claim client registration' `
+        ($LASTEXITCODE -eq 0 -and $noneState.state -eq 'installed') $noneState.state
+
     Add-Content -LiteralPath $server -Value 'tampered'
     & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'verify-install.ps1') `
         -Client Claude -ServerPath $server -SkipLive *> $null

--- a/scripts/install-completion.tests.ps1
+++ b/scripts/install-completion.tests.ps1
@@ -1,0 +1,144 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path ([IO.Path]::GetTempPath()) ('horizun-install-completion-' + [guid]::NewGuid().ToString('N'))
+$oldProfile = $env:USERPROFILE
+$oldLocal = $env:LOCALAPPDATA
+$oldAppData = $env:APPDATA
+$failed = 0
+
+function Assert([string]$Name, [bool]$Condition, [string]$Detail) {
+    if ($Condition) { Write-Host "  PASS  $Name" -ForegroundColor Green }
+    else {
+        Write-Host "  FAIL  $Name" -ForegroundColor Red
+        if ($Detail) { Write-Host "        $Detail" }
+        $script:failed++
+    }
+}
+
+try {
+    $env:USERPROFILE = Join-Path $root 'profile'
+    $env:LOCALAPPDATA = Join-Path $root 'local'
+    $env:APPDATA = Join-Path $root 'roaming'
+    New-Item -ItemType Directory -Path $env:USERPROFILE, $env:LOCALAPPDATA, $env:APPDATA -Force | Out-Null
+
+    $serverDir = Join-Path $env:LOCALAPPDATA 'Programs\Horizun\MCP\server'
+    New-Item -ItemType Directory -Path $serverDir -Force | Out-Null
+    $server = Join-Path $serverDir 'horizun-mcp.exe'
+    'fake server bytes for installation completion tests' | Set-Content -LiteralPath $server -Encoding ASCII
+    $serverHash = (Get-FileHash -LiteralPath $server -Algorithm SHA256).Hash.ToLowerInvariant()
+    [pscustomobject]@{
+        Schema = 2
+        Server = [pscustomobject]@{ Sha256 = $serverHash }
+        Plugins = @()
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path (Split-Path -Parent $serverDir) 'manifest.json') -Encoding UTF8
+
+    @'
+{
+  "theme": "keep-me",
+  "mcpServers": {
+    "other": { "command": "other.exe", "args": [] }
+  }
+}
+'@ | Set-Content -LiteralPath (Join-Path $env:USERPROFILE '.claude.json') -Encoding UTF8
+
+    # A deterministic process-state file reproduces the race even on a runner
+    # that already has a real Claude desktop app open.
+    $clientState = Join-Path $root 'running-clients.txt'
+    'Claude' | Set-Content -LiteralPath $clientState -Encoding ASCII
+
+    $status = Join-Path $env:LOCALAPPDATA 'Horizun\install-status.json'
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'complete-install.ps1') `
+        -Client Claude -ServerPath $server -StatusPath $status -WaitTimeoutMinutes 1 -NoResume -NoLiveWait `
+        -ClientStateFile $clientState
+    Assert 'an active client is safely scheduled, not treated as failure' ($LASTEXITCODE -eq 0) "exit $LASTEXITCODE"
+
+    $first = Get-Content -LiteralPath $status -Raw | ConvertFrom-Json
+    $before = Get-Content -LiteralPath (Join-Path $env:USERPROFILE '.claude.json') -Raw | ConvertFrom-Json
+    Assert 'state records that registration is waiting for client exit' ($first.state -eq 'waiting_for_client_exit') $first.state
+    Assert 'the active client configuration was not edited' ('horizun-revit' -notin @($before.mcpServers.PSObject.Properties.Name)) (($before.mcpServers.PSObject.Properties.Name) -join ', ')
+
+    Clear-Content -LiteralPath $clientState
+    $deadline = (Get-Date).AddSeconds(25)
+    $final = $null
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 500
+        if (Test-Path -LiteralPath $status) {
+            $final = Get-Content -LiteralPath $status -Raw | ConvertFrom-Json
+            if ($final.state -eq 'installed_and_registered') { break }
+        }
+    }
+    if (-not $final -or $final.state -ne 'installed_and_registered') {
+        foreach ($log in "$status.worker.log", "$status.worker-error.log") {
+            if (Test-Path -LiteralPath $log) {
+                Write-Host "        worker log: $log"
+                Get-Content -LiteralPath $log | ForEach-Object { Write-Host "        $_" }
+            }
+        }
+    }
+    Assert 'registration completes automatically after the client exits' ($final -and $final.state -eq 'installed_and_registered') $(if ($final) { $final.state } else { 'no state' })
+
+    $after = Get-Content -LiteralPath (Join-Path $env:USERPROFILE '.claude.json') -Raw | ConvertFrom-Json
+    Assert 'the expected Claude entry was added' ('horizun-revit' -in @($after.mcpServers.PSObject.Properties.Name)) (($after.mcpServers.PSObject.Properties.Name) -join ', ')
+    Assert 'unrelated Claude configuration survived' ($after.theme -eq 'keep-me' -and 'other' -in @($after.mcpServers.PSObject.Properties.Name)) $after.theme
+    Assert 'Claude points at the installed server' ($after.mcpServers.'horizun-revit'.command -eq $server) $after.mcpServers.'horizun-revit'.command
+
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'verify-install.ps1') `
+        -Client Claude -ServerPath $server -SkipLive
+    Assert 'standalone installation verification passes' ($LASTEXITCODE -eq 0) "exit $LASTEXITCODE"
+
+    # Exercise the other supported CLI through the same deferred path. This is
+    # not covered by proving Claude JSON: Codex uses TOML and needs the two long
+    # timeouts added without disturbing unrelated tables.
+    $codexDir = Join-Path $env:USERPROFILE '.codex'
+    New-Item -ItemType Directory -Path $codexDir -Force | Out-Null
+    @'
+model = "keep-me"
+
+[mcp_servers.other]
+command = 'other.exe'
+args = []
+'@ | Set-Content -LiteralPath (Join-Path $codexDir 'config.toml') -Encoding UTF8
+    'Codex' | Set-Content -LiteralPath $clientState -Encoding ASCII
+    $codexStatus = Join-Path $env:LOCALAPPDATA 'Horizun\codex-install-status.json'
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'complete-install.ps1') `
+        -Client Codex -ServerPath $server -StatusPath $codexStatus -WaitTimeoutMinutes 1 -NoResume -NoLiveWait `
+        -ClientStateFile $clientState
+    Assert 'an active Codex process is safely deferred' ($LASTEXITCODE -eq 0) "exit $LASTEXITCODE"
+    Clear-Content -LiteralPath $clientState
+    $deadline = (Get-Date).AddSeconds(25)
+    $codexFinal = $null
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 500
+        if (Test-Path -LiteralPath $codexStatus) {
+            $codexFinal = Get-Content -LiteralPath $codexStatus -Raw | ConvertFrom-Json
+            if ($codexFinal.state -eq 'installed_and_registered') { break }
+        }
+    }
+    Assert 'Codex registration completes automatically after exit' `
+        ($codexFinal -and $codexFinal.state -eq 'installed_and_registered') `
+        $(if ($codexFinal) { $codexFinal.state } else { 'no state' })
+    $codexText = Get-Content -LiteralPath (Join-Path $codexDir 'config.toml') -Raw
+    Assert 'Codex keeps unrelated configuration' ($codexText -match 'model = "keep-me"' -and $codexText -match '\[mcp_servers\.other\]') $codexText
+    $serverAsTomlJson = $server.Replace('\', '\\')
+    Assert 'Codex points at the installed server' ($codexText -match [regex]::Escape($serverAsTomlJson)) $codexText
+    Assert 'Codex receives Revit-safe timeouts' `
+        ($codexText -match '(?m)^startup_timeout_sec\s*=\s*120\s*$' -and $codexText -match '(?m)^tool_timeout_sec\s*=\s*600\s*$') $codexText
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'verify-install.ps1') `
+        -Client Codex -ServerPath $server -SkipLive *> $null
+    Assert 'standalone Codex installation verification passes' ($LASTEXITCODE -eq 0) "exit $LASTEXITCODE"
+
+    Add-Content -LiteralPath $server -Value 'tampered'
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'verify-install.ps1') `
+        -Client Claude -ServerPath $server -SkipLive *> $null
+    Assert 'manifest verification rejects a changed installed server' ($LASTEXITCODE -eq 1) "exit $LASTEXITCODE"
+}
+finally {
+    $env:USERPROFILE = $oldProfile
+    $env:LOCALAPPDATA = $oldLocal
+    $env:APPDATA = $oldAppData
+    if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
+if ($failed -gt 0) { throw "$failed install completion test(s) failed" }
+Write-Host 'install completion: ALL PASSED' -ForegroundColor Green

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -131,9 +131,11 @@ $clientTools = Join-Path $stage 'server\client-tools'
 New-Item -ItemType Directory -Path $clientTools -Force | Out-Null
 Copy-Item (Join-Path $repo 'scripts\register-client.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\verify-clients.ps1') $clientTools -Force
+Copy-Item (Join-Path $repo 'scripts\verify-install.ps1') $clientTools -Force
+Copy-Item (Join-Path $repo 'scripts\complete-install.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\hz-call.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\uninstall-cleanup.ps1') $clientTools -Force
-Step '  staged safe Codex/Claude registration and verification helpers'
+Step '  staged safe Codex/Claude registration, deferred completion and verification helpers'
 
 # --- The plugin, ONE ARTIFACT PER YEAR. --------------------------------------
 #

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -133,6 +133,7 @@ Copy-Item (Join-Path $repo 'scripts\register-client.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\verify-clients.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\verify-install.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\complete-install.ps1') $clientTools -Force
+Copy-Item (Join-Path $repo 'scripts\stop-installed-server.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\hz-call.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\uninstall-cleanup.ps1') $clientTools -Force
 Step '  staged safe Codex/Claude registration, deferred completion and verification helpers'

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -113,10 +113,17 @@ if ($sourceInstaller -notmatch $clientToolsCopy -or
     Fail 'the source installer no longer installs the deferred helpers and their on-disk identity manifest transactionally'
 }
 $stopHelper = Get-Content (Join-Path $repo 'scripts\stop-installed-server.ps1') -Raw
-if ($stopHelper -notmatch 'GetFullPath\(\$process\.Path\).*?-ieq \$target' -or
-    $stopHelper -notmatch "Get-Process -Name 'horizun-mcp'" -or
+if ($stopHelper -notmatch 'GetFullPath\(\$_\.ExecutablePath\).*?-ieq \$target' -or
+    $stopHelper -notmatch 'Get-CimInstance Win32_Process -Filter "Name=''horizun-mcp\.exe''"' -or
     $stopHelper -match 'taskkill|Stop-Process -Name') {
     Fail 'the update helper no longer limits process termination to the exact installed server path'
+}
+$installerSource = Get-Content (Join-Path $repo 'installer\horizun-mcp.iss') -Raw
+if ($installerSource -notmatch 'procedure RollbackDeployment' -or
+    $installerSource -notmatch 'function WriteDeploymentManifests' -or
+    $installerSource -notmatch 'if WriteDeploymentManifests then CommitDeployment' -or
+    $installerSource -match 'Source: "\.\.\\dist\\stage\\manifest\.json"; DestDir: "\{app\}"') {
+    Fail 'Setup no longer promotes server, add-ins and identity manifests as one transaction'
 }
 
 # Resolve every local link that will appear in the public repository. Anchors are

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -88,16 +88,18 @@ if ($ci -notmatch '\(\?m\)\^failed\[ \\t\]\*=\[ \\t\]\*\\S') {
 if ($ci -notmatch 'verify-release\.ps1 -Installed -AllowUnsigned -InstallResult') {
     Fail 'CI no longer verifies the exact per-run install result with an explicit signing policy'
 }
-if ($ci -notmatch 'SIGNING_CERT_THUMBPRINT' -or $ci -notmatch 'Stable release contains unsigned, invalid, self-signed or untimestamped') {
-    Fail 'stable tags no longer fail closed on missing or non-public Authenticode signing'
+if ($ci -notmatch 'SIGNING_CERT_THUMBPRINT' -or
+    $ci -notmatch '\.Major -ge 1' -or
+    $ci -notmatch 'Horizun 1\.0\+ release contains unsigned, invalid, self-signed or untimestamped') {
+    Fail '1.0+ tags no longer fail closed on missing or non-public Authenticode signing'
 }
 if ($ci -notmatch 'runs-on: windows-latest' -or
     $ci -notmatch 'not publicly trusted on a clean Windows runner' -or
     $ci -notmatch 'needs: \[package, public-signature, stable-release-evidence\]') {
     Fail 'stable publication no longer proves public trust on a clean hosted Windows runner'
 }
-if ($ci -notmatch '(?s)startsWith\(github\.ref.*?verify-release\.ps1 -Installed -InstallResult.*?else.*?-AllowUnsigned') {
-    Fail 'installed release verification no longer removes the unsigned exception for stable tags only'
+if ($ci -notmatch '(?s)requiresPublicSignature.*?\.Major -ge 1.*?verify-release\.ps1 -Installed -InstallResult.*?else.*?-AllowUnsigned') {
+    Fail 'installed release verification no longer allows unsigned only before 1.0'
 }
 
 $readme = Get-Content (Join-Path $repo 'README.md') -Raw
@@ -111,7 +113,10 @@ $codeowners = Get-Content (Join-Path $repo '.github/CODEOWNERS') -Raw
 if ($readme -notmatch 'CODE-SIGNING-POLICY\.md' -or $readme -notmatch 'Free code signing provided by SignPath\.io, certificate\s+by SignPath Foundation') {
     Fail 'README no longer exposes the required SignPath code-signing statement and policy'
 }
-if ($signingPolicy -notmatch 'application was submitted on 2026-08-15' -or $signingPolicy -notmatch 'GitHub-hosted runners' -or $signingPolicy -notmatch 'docs/PRIVACY\.md') {
+if ($signingPolicy -notmatch 'application was submitted on 2026-08-15' -or
+    $signingPolicy -notmatch 'Version 1\.0\.0 and every later release is blocked' -or
+    $signingPolicy -notmatch 'GitHub-hosted runners' -or
+    $signingPolicy -notmatch 'docs/PRIVACY\.md') {
     Fail 'code-signing policy no longer states its submitted status, trusted origin and privacy boundary'
 }
 if ($privacyPolicy -notmatch 'does not automatically upload' -or $privacyPolicy -notmatch 'horizun_power_bi_push' -or $privacyPolicy -notmatch 'horizun_execute_python') {

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -111,8 +111,8 @@ $codeowners = Get-Content (Join-Path $repo '.github/CODEOWNERS') -Raw
 if ($readme -notmatch 'CODE-SIGNING-POLICY\.md' -or $readme -notmatch 'Free code signing provided by SignPath\.io, certificate\s+by SignPath Foundation') {
     Fail 'README no longer exposes the required SignPath code-signing statement and policy'
 }
-if ($signingPolicy -notmatch 'application is pending' -or $signingPolicy -notmatch 'GitHub-hosted runners' -or $signingPolicy -notmatch 'docs/PRIVACY\.md') {
-    Fail 'code-signing policy no longer states its pending status, trusted origin and privacy boundary'
+if ($signingPolicy -notmatch 'application was submitted on 2026-08-15' -or $signingPolicy -notmatch 'GitHub-hosted runners' -or $signingPolicy -notmatch 'docs/PRIVACY\.md') {
+    Fail 'code-signing policy no longer states its submitted status, trusted origin and privacy boundary'
 }
 if ($privacyPolicy -notmatch 'does not automatically upload' -or $privacyPolicy -notmatch 'horizun_power_bi_push' -or $privacyPolicy -notmatch 'horizun_execute_python') {
     Fail 'privacy policy no longer names the automatic and user-requested data boundaries'

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -69,6 +69,7 @@ if ($contract -notmatch 'Enabled by default' -or $contract -notmatch 'host_verif
 $ci = Get-Content (Join-Path $repo '.github/workflows/ci.yml') -Raw
 $runnerGate = Get-Content (Join-Path $repo 'scripts/run-release-live-gate.ps1') -Raw
 $hzCall = Get-Content (Join-Path $repo 'scripts/hz-call.ps1') -Raw
+if ($ci -notmatch 'scan-sensitive\.tests\.ps1') { Fail 'CI no longer tests the narrow public-governance scanner exception' }
 if ($ci -notmatch 'run-release-live-gate\.ps1') { Fail 'CI no longer invokes the owned Revit release lifecycle' }
 if ($ci -notmatch '(?s)revit-integration:.*?max-parallel:\s*1.*?matrix:') { Fail 'the single interactive Revit integration matrix is no longer serialized' }
 if ($ci -notmatch "'stage\.zip'\s*=\s*'dist/stage\.zip'") { Fail 'the package record no longer hashes the complete staged payload archive' }

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -88,6 +88,30 @@ if ($ci -notmatch '\(\?m\)\^failed\[ \\t\]\*=\[ \\t\]\*\\S') {
 if ($ci -notmatch 'verify-release\.ps1 -Installed -AllowUnsigned -InstallResult') {
     Fail 'CI no longer verifies the exact per-run install result with an explicit signing policy'
 }
+if ($ci -notmatch 'SIGNING_CERT_THUMBPRINT' -or $ci -notmatch 'Stable release contains unsigned, invalid, self-signed or untimestamped') {
+    Fail 'stable tags no longer fail closed on missing or non-public Authenticode signing'
+}
+if ($ci -notmatch 'runs-on: windows-latest' -or
+    $ci -notmatch 'not publicly trusted on a clean Windows runner' -or
+    $ci -notmatch 'needs: \[package, public-signature, stable-release-evidence\]') {
+    Fail 'stable publication no longer proves public trust on a clean hosted Windows runner'
+}
+if ($ci -notmatch '(?s)startsWith\(github\.ref.*?verify-release\.ps1 -Installed -InstallResult.*?else.*?-AllowUnsigned') {
+    Fail 'installed release verification no longer removes the unsigned exception for stable tags only'
+}
+
+$readme = Get-Content (Join-Path $repo 'README.md') -Raw
+if ($readme -notmatch 'irm https://raw\.githubusercontent\.com/HorizunGroup/horizun-revit-mcp/main/install-release\.ps1 \| iex') {
+    Fail 'the public README no longer offers the one-paste release installer'
+}
+
+$sourceInstaller = Get-Content (Join-Path $repo 'install.ps1') -Raw
+$clientToolsCopy = [regex]::Escape("Copy-Item (Join-Path `$serverStage 'client-tools') `$installedClientTools -Recurse -Force")
+if ($sourceInstaller -notmatch $clientToolsCopy -or
+    $sourceInstaller -notmatch 'SourceInstall = \$true' -or
+    $sourceInstaller -notmatch 'Move-Item -LiteralPath \$manifestTemp -Destination \$installedManifest') {
+    Fail 'the source installer no longer installs the deferred helpers and their on-disk identity manifest transactionally'
+}
 
 # Resolve every local link that will appear in the public repository. Anchors are
 # deliberately ignored here; missing files are the high-cost publication defect.

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -105,6 +105,22 @@ if ($readme -notmatch 'irm https://raw\.githubusercontent\.com/HorizunGroup/hori
     Fail 'the public README no longer offers the one-paste release installer'
 }
 
+$signingPolicy = Get-Content (Join-Path $repo 'CODE-SIGNING-POLICY.md') -Raw
+$privacyPolicy = Get-Content (Join-Path $repo 'docs/PRIVACY.md') -Raw
+$codeowners = Get-Content (Join-Path $repo '.github/CODEOWNERS') -Raw
+if ($readme -notmatch 'CODE-SIGNING-POLICY\.md' -or $readme -notmatch 'Free code signing provided by SignPath\.io, certificate\s+by SignPath Foundation') {
+    Fail 'README no longer exposes the required SignPath code-signing statement and policy'
+}
+if ($signingPolicy -notmatch 'application is pending' -or $signingPolicy -notmatch 'GitHub-hosted runners' -or $signingPolicy -notmatch 'docs/PRIVACY\.md') {
+    Fail 'code-signing policy no longer states its pending status, trusted origin and privacy boundary'
+}
+if ($privacyPolicy -notmatch 'does not automatically upload' -or $privacyPolicy -notmatch 'horizun_power_bi_push' -or $privacyPolicy -notmatch 'horizun_execute_python') {
+    Fail 'privacy policy no longer names the automatic and user-requested data boundaries'
+}
+if ($codeowners -notmatch '/\.github/workflows/' -or $codeowners -notmatch '/CODE-SIGNING-POLICY\.md') {
+    Fail 'signing policy and workflows are no longer covered by CODEOWNERS'
+}
+
 $sourceInstaller = Get-Content (Join-Path $repo 'install.ps1') -Raw
 $clientToolsCopy = [regex]::Escape("Copy-Item (Join-Path `$serverStage 'client-tools') `$installedClientTools -Recurse -Force")
 if ($sourceInstaller -notmatch $clientToolsCopy -or

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -112,6 +112,12 @@ if ($sourceInstaller -notmatch $clientToolsCopy -or
     $sourceInstaller -notmatch 'Move-Item -LiteralPath \$manifestTemp -Destination \$installedManifest') {
     Fail 'the source installer no longer installs the deferred helpers and their on-disk identity manifest transactionally'
 }
+$stopHelper = Get-Content (Join-Path $repo 'scripts\stop-installed-server.ps1') -Raw
+if ($stopHelper -notmatch 'GetFullPath\(\$process\.Path\).*?-ieq \$target' -or
+    $stopHelper -notmatch "Get-Process -Name 'horizun-mcp'" -or
+    $stopHelper -match 'taskkill|Stop-Process -Name') {
+    Fail 'the update helper no longer limits process termination to the exact installed server path'
+}
 
 # Resolve every local link that will appear in the public repository. Anchors are
 # deliberately ignored here; missing files are the high-cost publication defect.

--- a/scripts/scan-sensitive.ps1
+++ b/scripts/scan-sensitive.ps1
@@ -100,6 +100,31 @@ try {
         }) | Out-Null
     }
 
+    # Public maintainer identities are required in CODEOWNERS and in the signing
+    # governance policy. A private client-name term can legitimately be part of a
+    # maintainer's public GitHub handle, so exempt only a hit that is fully inside
+    # a GitHub handle (or its profile URL), and only in those two governance files.
+    # The same word anywhere else in either file is still a finding.
+    function Test-PublicGovernanceTermHit([string] $file, [string] $line, $hit) {
+        $patterns = switch ($file.Replace('\','/')) {
+            '.github/CODEOWNERS'      { @('@[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})') }
+            'CODE-SIGNING-POLICY.md' { @(
+                '@[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})',
+                'https://github\.com/[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})'
+            ) }
+            default { @() }
+        }
+        foreach ($pattern in $patterns) {
+            foreach ($span in [regex]::Matches($line, $pattern)) {
+                if ($hit.Index -ge $span.Index -and
+                    ($hit.Index + $hit.Length) -le ($span.Index + $span.Length)) {
+                    return $true
+                }
+            }
+        }
+        return $false
+    }
+
     # --- structural rules: no wordlist needed ------------------------------
     #
     # Each one is a SHAPE that leaks whoever the client turns out to be. The
@@ -175,7 +200,15 @@ try {
                 foreach ($line in (Get-Content -LiteralPath $f -ErrorAction SilentlyContinue)) {
                     $n++
                     foreach ($t in $terms) {
-                        if ($line -match [regex]::Escape($t)) {
+                        $termHits = @([regex]::Matches(
+                            $line,
+                            [regex]::Escape($t),
+                            [Text.RegularExpressions.RegexOptions]::IgnoreCase
+                        ))
+                        $unapproved = @($termHits | Where-Object {
+                            -not (Test-PublicGovernanceTermHit $f $line $_)
+                        })
+                        if ($unapproved.Count -gt 0) {
                             # The TERM is not echoed into the output. A CI log is a
                             # published artifact, and a scanner that prints the
                             # secret it found has moved the leak rather than closed

--- a/scripts/scan-sensitive.tests.ps1
+++ b/scripts/scan-sensitive.tests.ps1
@@ -1,0 +1,42 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+
+$scanner = Join-Path $PSScriptRoot 'scan-sensitive.ps1'
+$engine = (Get-Process -Id $PID).Path
+$root = Join-Path ([IO.Path]::GetTempPath()) ('horizun-sensitive-test-' + [guid]::NewGuid().ToString('N'))
+$terms = "$root-terms.txt"
+$json = Join-Path $root 'result.json'
+
+try {
+    New-Item -ItemType Directory -Force (Join-Path $root '.github') | Out-Null
+    Set-Content -LiteralPath $terms -Value 'alice' -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $root '.github/CODEOWNERS') `
+        -Value '/.github/workflows/ @alice-maintainer' -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $root 'CODE-SIGNING-POLICY.md') `
+        -Value 'Maintainer: [@alice-maintainer](https://github.com/alice-maintainer)' -Encoding utf8
+
+    & $engine -NoProfile -ExecutionPolicy Bypass -File $scanner `
+        -Root $root -AllFiles -TermsFile $terms -RequireTerms -Json $json
+    if ($LASTEXITCODE -ne 0) {
+        throw 'public GitHub maintainer identities were reported as private client data'
+    }
+    $clean = Get-Content -LiteralPath $json -Raw | ConvertFrom-Json
+    if ($clean.finding_count -ne 0) { throw 'governance-only fixture was not clean' }
+
+    Set-Content -LiteralPath (Join-Path $root 'README.md') `
+        -Value 'Customer delivery for Alice' -Encoding utf8
+    & $engine -NoProfile -ExecutionPolicy Bypass -File $scanner `
+        -Root $root -AllFiles -TermsFile $terms -RequireTerms -Json $json
+    if ($LASTEXITCODE -ne 1) { throw "a private-name leak exited $LASTEXITCODE instead of 1" }
+    $leak = Get-Content -LiteralPath $json -Raw | ConvertFrom-Json
+    $rows = @($leak.findings | Where-Object { $_.file -eq 'README.md' -and $_.rule -eq 'sensitive-term' })
+    if ($rows.Count -ne 1) { throw 'the same term outside public governance was not reported exactly once' }
+
+    Write-Host '[PASS] public GitHub governance identities are narrow exceptions; the same term elsewhere still fails' -ForegroundColor Green
+}
+finally {
+    if (Test-Path -LiteralPath $root) {
+        Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $terms -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/server-update.tests.ps1
+++ b/scripts/server-update.tests.ps1
@@ -1,0 +1,42 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param([switch]$RequireWindows)
+$ErrorActionPreference = 'Stop'
+
+if ($env:OS -ne 'Windows_NT') {
+    if ($RequireWindows) { throw 'server update process-scoping test requires Windows' }
+    Write-Host '[SKIP] server update process-scoping test requires Windows'
+    exit 0
+}
+
+$root = Join-Path ([IO.Path]::GetTempPath()) ('horizun-server-update-' + [guid]::NewGuid().ToString('N'))
+$a = Join-Path $root 'installed\horizun-mcp.exe'
+$b = Join-Path $root 'unrelated\horizun-mcp.exe'
+$processA = $null
+$processB = $null
+try {
+    New-Item -ItemType Directory -Path (Split-Path -Parent $a), (Split-Path -Parent $b) -Force | Out-Null
+    Copy-Item "$env:SystemRoot\System32\ping.exe" $a -Force
+    Copy-Item "$env:SystemRoot\System32\ping.exe" $b -Force
+    $processA = Start-Process -FilePath $a -ArgumentList '-t','127.0.0.1' -WindowStyle Hidden -PassThru
+    $processB = Start-Process -FilePath $b -ArgumentList '-t','127.0.0.1' -WindowStyle Hidden -PassThru
+    Start-Sleep -Milliseconds 500
+
+    & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'stop-installed-server.ps1') `
+        -ServerPath $a -WaitSeconds 10
+    if ($LASTEXITCODE -ne 0) { throw "stop helper failed ($LASTEXITCODE)" }
+    $processA.Refresh()
+    $processB.Refresh()
+    if (-not $processA.HasExited) { throw 'the exact installed target was not stopped' }
+    if ($processB.HasExited) { throw 'an unrelated same-name executable was stopped' }
+    Write-Host '[PASS] updater stops only the exact installed server path'
+}
+finally {
+    foreach ($process in $processA, $processB) {
+        if ($process) {
+            try { $process.Refresh(); if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force } } catch { }
+            $process.Dispose()
+        }
+    }
+    if (Test-Path -LiteralPath $root) { Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue }
+}

--- a/scripts/stop-installed-server.ps1
+++ b/scripts/stop-installed-server.ps1
@@ -17,34 +17,27 @@ $ErrorActionPreference = 'Stop'
 if ($WaitSeconds -lt 1 -or $WaitSeconds -gt 60) { throw 'WaitSeconds must be between 1 and 60.' }
 
 $target = [IO.Path]::GetFullPath($ServerPath).TrimEnd('\')
-$matches = New-Object System.Collections.Generic.List[System.Diagnostics.Process]
-foreach ($process in @(Get-Process -Name 'horizun-mcp' -ErrorAction SilentlyContinue)) {
-    try {
-        if ($process.Path -and [IO.Path]::GetFullPath($process.Path).TrimEnd('\') -ieq $target) {
-            $matches.Add($process)
+$matches = @(
+    Get-CimInstance Win32_Process -Filter "Name='horizun-mcp.exe'" -ErrorAction Stop |
+        Where-Object {
+            $_.ExecutablePath -and
+            [IO.Path]::GetFullPath($_.ExecutablePath).TrimEnd('\') -ieq $target
         }
-    }
-    catch {
-        # A process that exited between enumeration and inspection needs no stop.
-        if (-not $process.HasExited) { throw }
-    }
-}
+)
 
 foreach ($process in $matches) {
-    Write-Host "[Horizun] stopping installed MCP server pid $($process.Id) for update"
-    Stop-Process -Id $process.Id -Force -ErrorAction Stop
+    Write-Host "[Horizun] stopping installed MCP server pid $($process.ProcessId) for update"
+    Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
 }
 
 $deadline = (Get-Date).AddSeconds($WaitSeconds)
 do {
     $remaining = @()
-    foreach ($process in @(Get-Process -Name 'horizun-mcp' -ErrorAction SilentlyContinue)) {
-        try {
-            if ($process.Path -and [IO.Path]::GetFullPath($process.Path).TrimEnd('\') -ieq $target) {
-                $remaining += $process.Id
-            }
+    foreach ($process in @(Get-CimInstance Win32_Process -Filter "Name='horizun-mcp.exe'" -ErrorAction SilentlyContinue)) {
+        if ($process.ExecutablePath -and
+            [IO.Path]::GetFullPath($process.ExecutablePath).TrimEnd('\') -ieq $target) {
+            $remaining += $process.ProcessId
         }
-        catch { }
     }
     if ($remaining.Count -eq 0) { exit 0 }
     Start-Sleep -Milliseconds 200

--- a/scripts/stop-installed-server.ps1
+++ b/scripts/stop-installed-server.ps1
@@ -1,0 +1,54 @@
+#Requires -Version 5.1
+<#
+  Stop only MCP server processes running from the exact installed path.
+
+  A release update is intentionally allowed while Claude/Codex is open: those
+  clients keep the server image loaded even though Revit is closed, and Windows
+  then refuses the directory swap. Setup calls this helper only after its
+  Revit-running guard passed. The client itself is never stopped; completion is
+  deferred until the client exits normally.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$ServerPath,
+    [int]$WaitSeconds = 10
+)
+$ErrorActionPreference = 'Stop'
+if ($WaitSeconds -lt 1 -or $WaitSeconds -gt 60) { throw 'WaitSeconds must be between 1 and 60.' }
+
+$target = [IO.Path]::GetFullPath($ServerPath).TrimEnd('\')
+$matches = New-Object System.Collections.Generic.List[System.Diagnostics.Process]
+foreach ($process in @(Get-Process -Name 'horizun-mcp' -ErrorAction SilentlyContinue)) {
+    try {
+        if ($process.Path -and [IO.Path]::GetFullPath($process.Path).TrimEnd('\') -ieq $target) {
+            $matches.Add($process)
+        }
+    }
+    catch {
+        # A process that exited between enumeration and inspection needs no stop.
+        if (-not $process.HasExited) { throw }
+    }
+}
+
+foreach ($process in $matches) {
+    Write-Host "[Horizun] stopping installed MCP server pid $($process.Id) for update"
+    Stop-Process -Id $process.Id -Force -ErrorAction Stop
+}
+
+$deadline = (Get-Date).AddSeconds($WaitSeconds)
+do {
+    $remaining = @()
+    foreach ($process in @(Get-Process -Name 'horizun-mcp' -ErrorAction SilentlyContinue)) {
+        try {
+            if ($process.Path -and [IO.Path]::GetFullPath($process.Path).TrimEnd('\') -ieq $target) {
+                $remaining += $process.Id
+            }
+        }
+        catch { }
+    }
+    if ($remaining.Count -eq 0) { exit 0 }
+    Start-Sleep -Milliseconds 200
+} while ((Get-Date) -lt $deadline)
+
+Write-Error "Installed Horizun MCP server processes did not stop: $($remaining -join ', ')"
+exit 1

--- a/scripts/verify-install.ps1
+++ b/scripts/verify-install.ps1
@@ -218,6 +218,7 @@ if (-not $SkipLive -and $problems.Count -eq 0) {
 }
 
 $state = if ($problems.Count -gt 0) { 'failed' }
+         elseif ($SkipLive -and $resolvedClient -eq 'None') { 'installed' }
          elseif ($SkipLive) { 'installed_and_registered' }
          elseif ($livePending) { 'awaiting_revit' }
          else { 'live_verified' }

--- a/scripts/verify-install.ps1
+++ b/scripts/verify-install.ps1
@@ -1,0 +1,249 @@
+#Requires -Version 5.1
+<#
+  Verify the installed Horizun release without trusting the installer's exit code.
+
+  The checks are deliberately layered:
+    1. the installed server and every installed Revit payload match manifest.json;
+    2. the requested client configuration points at that exact server, preserving
+       the long timeouts Revit work needs;
+    3. when Revit is running, the installed server answers horizun_health.
+
+  Revit must be closed while Setup replaces the add-in, so a correct fresh install
+  normally finishes in `awaiting_revit`. complete-install.ps1 keeps that last check
+  pending and completes it automatically after the first Revit start.
+
+  Exit codes: 0 verified for the state currently available
+              1 a check failed
+              3 live verification was required but Revit is not available yet
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Auto', 'Claude', 'Codex', 'Both', 'None')]
+    [string]$Client = 'Auto',
+    [string]$Name = 'horizun-revit',
+    [string]$ServerPath,
+    [string]$ManifestPath,
+    [switch]$SkipLive,
+    [switch]$RequireLive,
+    [string]$Json
+)
+$ErrorActionPreference = 'Stop'
+
+if (-not $ServerPath) {
+    $ServerPath = Join-Path $env:LOCALAPPDATA 'Programs\Horizun\MCP\server\horizun-mcp.exe'
+}
+if (-not $ManifestPath) {
+    $ManifestPath = Join-Path (Split-Path -Parent (Split-Path -Parent $ServerPath)) 'manifest.json'
+}
+
+$claudeConfig = Join-Path $env:USERPROFILE '.claude.json'
+$codexConfig = Join-Path $env:USERPROFILE '.codex\config.toml'
+$checks = New-Object System.Collections.Generic.List[object]
+$problems = New-Object System.Collections.Generic.List[string]
+$livePending = $false
+$health = $null
+
+function Check([string]$Label, [bool]$Ok, [string]$Detail) {
+    $script:checks.Add([pscustomobject]@{ check = $Label; ok = $Ok; detail = $Detail }) | Out-Null
+    if ($Ok) { Write-Host ("  OK    {0}" -f $Label) -ForegroundColor Green }
+    else {
+        Write-Host ("  WRONG {0} - {1}" -f $Label, $Detail) -ForegroundColor Red
+        $script:problems.Add("$Label : $Detail") | Out-Null
+    }
+}
+
+function Resolve-RequestedClient([string]$Requested) {
+    if ($Requested -ne 'Auto') { return $Requested }
+    $hasClaude = Test-Path -LiteralPath $claudeConfig
+    $hasCodex = Test-Path -LiteralPath $codexConfig
+    if ($hasClaude -and $hasCodex) { return 'Both' }
+    if ($hasClaude) { return 'Claude' }
+    if ($hasCodex) { return 'Codex' }
+    return 'None'
+}
+
+function Get-CodexTable([string[]]$Lines, [string]$Header) {
+    $start = -1
+    for ($i = 0; $i -lt $Lines.Count; $i++) {
+        if ($Lines[$i].Trim() -eq $Header) { $start = $i; break }
+    }
+    if ($start -lt 0) { return @() }
+    $end = $Lines.Count
+    for ($i = $start + 1; $i -lt $Lines.Count; $i++) {
+        $trim = $Lines[$i].Trim()
+        if ($trim -match '^\[[^\]]+\]$' -and
+            $trim -notmatch "^\[mcp_servers\.$([regex]::Escape($Name))\.") {
+            $end = $i
+            break
+        }
+    }
+    if ($end -le $start) { return @() }
+    return @($Lines[$start..($end - 1)])
+}
+
+function Resolve-FullPath([string]$Path) {
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+    try { return [IO.Path]::GetFullPath($Path).TrimEnd('\') }
+    catch { return $Path.TrimEnd('\') }
+}
+
+Write-Host ''
+Write-Host 'Horizun installation verification' -ForegroundColor Cyan
+Write-Host ('-' * 72)
+
+# The release manifest is the installer's statement of exactly what it shipped.
+$manifest = $null
+Check 'the installed MCP server exists' (Test-Path -LiteralPath $ServerPath -PathType Leaf) $ServerPath
+Check 'the installed release manifest exists' (Test-Path -LiteralPath $ManifestPath -PathType Leaf) $ManifestPath
+if ((Test-Path -LiteralPath $ServerPath) -and (Test-Path -LiteralPath $ManifestPath)) {
+    try {
+        $manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+        Check 'manifest schema is supported' ($manifest.Schema -eq 2) "schema '$($manifest.Schema)'"
+        $serverHash = (Get-FileHash -LiteralPath $ServerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        Check 'installed server matches the release manifest' ($serverHash -eq [string]$manifest.Server.Sha256) `
+            "installed $serverHash; manifest $($manifest.Server.Sha256)"
+    }
+    catch {
+        Check 'release manifest parses' $false $_.Exception.Message
+    }
+}
+
+# Only a Revit version actually present on this machine should have been installed.
+# A release contains all five payloads; requiring all five under AppData on a machine
+# with one Revit would incorrectly condemn a correct selective install.
+if ($manifest) {
+    foreach ($plugin in @($manifest.Plugins)) {
+        $year = [int]$plugin.Year
+        $revitApi = "C:\Program Files\Autodesk\Revit $year\RevitAPI.dll"
+        if (-not (Test-Path -LiteralPath $revitApi)) { continue }
+        $addin = Join-Path $env:APPDATA "Autodesk\Revit\Addins\$year\Horizun.addin"
+        $dll = Join-Path $env:APPDATA "Autodesk\Revit\Addins\$year\Horizun\Horizun.Revit.dll"
+        Check "Revit $year add-in manifest exists" (Test-Path -LiteralPath $addin -PathType Leaf) $addin
+        Check "Revit $year add-in binary exists" (Test-Path -LiteralPath $dll -PathType Leaf) $dll
+        if (Test-Path -LiteralPath $dll) {
+            $hash = (Get-FileHash -LiteralPath $dll -Algorithm SHA256).Hash.ToLowerInvariant()
+            Check "Revit $year binary matches the release manifest" ($hash -eq [string]$plugin.Sha256) `
+                "installed $hash; manifest $($plugin.Sha256)"
+        }
+    }
+}
+
+$resolvedClient = Resolve-RequestedClient $Client
+$expectedServer = Resolve-FullPath $ServerPath
+
+if ($resolvedClient -eq 'Claude' -or $resolvedClient -eq 'Both') {
+    Check 'Claude configuration exists' (Test-Path -LiteralPath $claudeConfig -PathType Leaf) $claudeConfig
+    if (Test-Path -LiteralPath $claudeConfig) {
+        try {
+            $cfg = Get-Content -LiteralPath $claudeConfig -Raw | ConvertFrom-Json
+            $entry = $cfg.mcpServers.$Name
+            Check "Claude has MCP entry '$Name'" ($null -ne $entry) 'entry not found'
+            if ($entry) {
+                $actual = Resolve-FullPath ([string]$entry.command)
+                Check 'Claude points at the installed server' ($actual -ieq $expectedServer) "$actual"
+            }
+        }
+        catch { Check 'Claude configuration parses' $false $_.Exception.Message }
+    }
+}
+
+if ($resolvedClient -eq 'Codex' -or $resolvedClient -eq 'Both') {
+    Check 'Codex configuration exists' (Test-Path -LiteralPath $codexConfig -PathType Leaf) $codexConfig
+    if (Test-Path -LiteralPath $codexConfig) {
+        try {
+            $lines = @(Get-Content -LiteralPath $codexConfig)
+            $table = @(Get-CodexTable $lines "[mcp_servers.$Name]")
+            Check "Codex has MCP entry '$Name'" ($table.Count -gt 0) 'entry not found'
+            if ($table.Count -gt 0) {
+                $command = $null
+                foreach ($line in $table) {
+                    if ($line -match '^\s*command\s*=\s*("(?:[^"\\]|\\.)*")\s*$') {
+                        $command = ($Matches[1] | ConvertFrom-Json)
+                    }
+                    elseif ($line -match "^\s*command\s*=\s*'([^']*)'\s*$") { $command = $Matches[1] }
+                }
+                $actual = Resolve-FullPath ([string]$command)
+                Check 'Codex points at the installed server' ($actual -ieq $expectedServer) "$actual"
+                Check 'Codex startup timeout is 120 seconds' (($table -join "`n") -match '(?m)^\s*startup_timeout_sec\s*=\s*120\s*$') 'missing or different'
+                Check 'Codex tool timeout is 600 seconds' (($table -join "`n") -match '(?m)^\s*tool_timeout_sec\s*=\s*600\s*$') 'missing or different'
+            }
+        }
+        catch { Check 'Codex configuration can be inspected' $false $_.Exception.Message }
+    }
+}
+
+if (-not $SkipLive -and $problems.Count -eq 0) {
+    $call = Join-Path $PSScriptRoot 'hz-call.ps1'
+    if (-not (Test-Path -LiteralPath $call)) {
+        Check 'live verification helper exists' $false $call
+    }
+    else {
+        $targetJson = Join-Path ([IO.Path]::GetTempPath()) ('horizun-target-' + [guid]::NewGuid().ToString('N') + '.json')
+        $healthJson = Join-Path ([IO.Path]::GetTempPath()) ('horizun-health-' + [guid]::NewGuid().ToString('N') + '.json')
+        try {
+            & powershell -NoProfile -ExecutionPolicy Bypass -File $call -Tool horizun_target `
+                -Server $ServerPath -TimeoutSec 30 -Quiet -Json $targetJson
+            $targetExit = $LASTEXITCODE
+            $target = if (Test-Path -LiteralPath $targetJson) { Get-Content -LiteralPath $targetJson -Raw | ConvertFrom-Json } else { $null }
+            $found = if ($target -and $target.result) { [int]$target.result.targets_found } else { 0 }
+            if ($targetExit -ne 0) {
+                Check 'the installed server answers horizun_target' $false "exit code $targetExit"
+            }
+            elseif ($found -lt 1) {
+                $livePending = $true
+                if ($RequireLive) {
+                    Write-Host '  WAIT  Revit is not running yet; horizun_health remains pending.' -ForegroundColor Yellow
+                }
+                else {
+                    Write-Host '  READY Revit is not running; on-disk and client checks are complete.' -ForegroundColor Cyan
+                }
+            }
+            else {
+                & powershell -NoProfile -ExecutionPolicy Bypass -File $call -Tool horizun_health `
+                    -Server $ServerPath -TimeoutSec 120 -Quiet -Json $healthJson
+                $healthExit = $LASTEXITCODE
+                $healthReply = if (Test-Path -LiteralPath $healthJson) { Get-Content -LiteralPath $healthJson -Raw | ConvertFrom-Json } else { $null }
+                $health = if ($healthReply) { $healthReply.result } else { $null }
+                Check 'horizun_health answers through the installed server' ($healthExit -eq 0 -and $null -ne $health) `
+                    "exit code $healthExit"
+                if ($health) {
+                    Check 'horizun_health reports healthy' ([string]$health.status -eq 'healthy') "status '$($health.status)'"
+                }
+            }
+        }
+        finally {
+            Remove-Item -LiteralPath $targetJson, $healthJson -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+$state = if ($problems.Count -gt 0) { 'failed' }
+         elseif ($SkipLive) { 'installed_and_registered' }
+         elseif ($livePending) { 'awaiting_revit' }
+         else { 'live_verified' }
+
+$report = [pscustomobject]@{
+    schema = 1
+    generated_utc = (Get-Date).ToUniversalTime().ToString('o')
+    state = $state
+    client = $resolvedClient
+    server_path = $ServerPath
+    manifest_path = $ManifestPath
+    checks = $checks
+    problems = $problems
+    health = $health
+}
+if ($Json) {
+    $dir = Split-Path -Parent $Json
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    $tmp = "$Json.tmp-$([guid]::NewGuid().ToString('N'))"
+    $report | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $tmp -Encoding UTF8
+    Move-Item -LiteralPath $tmp -Destination $Json -Force
+    Write-Host "  wrote $Json"
+}
+
+Write-Host ('-' * 72)
+if ($problems.Count -gt 0) { exit 1 }
+if ($RequireLive -and $livePending) { exit 3 }
+Write-Host "  $state" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
Implements one-action installation for Claude and Codex with safe deferred registration, durable resume, installed-hash verification, first-Revit health verification, active-server updates scoped to the exact installed path, and atomic server/add-in/manifest rollback.

Release decision for 0.9.0: publish with an explicit unsigned disclosure while the SignPath Foundation application is reviewed. SHA-256 checksums, CycloneDX SBOM, provenance, immutable-package installation and the complete live matrix remain mandatory. From 1.0.0 onward, CI requires publicly trusted, timestamped Authenticode signatures with no unsigned exception.

Evidence for the final PR merge ref (run 31891962324):
- 864 .NET tests passed, 0 skipped.
- Server and Revit 2023-2027 builds: 0 warnings, 0 errors.
- Dependency audit, CodeQL, full private sensitive-name scan and release-script suites passed.
- Installer built, downloaded, hash-verified, installed once and matched back to its manifest.
- Revit 2023, 2024, 2025, 2026 and 2027: 73/73 live probes each; 0 failed, 0 unverified, 0 not covered.

The tag workflow will rebuild and repeat the complete release gate from the final main commit before GitHub Release publication.