### PR TITLE
Fix stable release publication outside a checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,6 +784,7 @@ jobs:
 
       - name: Create or complete the stable GitHub release
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -99,6 +99,9 @@ if ($ci -notmatch 'runs-on: windows-latest' -or
     $ci -notmatch 'needs: \[package, public-signature, stable-release-evidence\]') {
     Fail 'stable publication no longer proves public trust on a clean hosted Windows runner'
 }
+if ($ci -notmatch '(?s)Create or complete the stable GitHub release.*?GH_REPO:\s*\$\{\{\s*github\.repository\s*\}\}.*?gh release') {
+    Fail 'stable release publication can no longer identify the repository without a checkout'
+}
 if ($ci -notmatch '(?s)requiresPublicSignature.*?\.Major -ge 1.*?verify-release\.ps1 -Installed -InstallResult.*?else.*?-AllowUnsigned') {
     Fail 'installed release verification no longer allows unsigned only before 1.0'
 }


### PR DESCRIPTION
## Summary
- pass the repository explicitly to GitHub CLI in the artifact-only release job
- add a regression check for repository discovery

## Validation
- scripts/public-consistency.tests.ps1
- GitHub CLI release lookup from a directory without .git now reaches the repository and returns only release not found