### PR TITLE
docs: make the release page usable by someone installing

### DIFF
--- a/.github/release-preamble.md
+++ b/.github/release-preamble.md
@@ -1,0 +1,30 @@
+## Install
+
+**You need:** Windows, at least one Revit 2023–2027, and **Revit closed**. Nothing else — no Git, no .NET SDK on this path.
+
+**1 · Download and verify.** Take `horizun-mcp-<version>-setup.exe` and `SHA256SUMS.txt` from the assets below, then check the download before you run it:
+
+```powershell
+$exe  = Get-Item .\horizun-mcp-*-setup.exe
+$want = (Select-String -Path .\SHA256SUMS.txt -Pattern 'setup.exe').Line.Split(' ')[0]
+if ((Get-FileHash $exe -Algorithm SHA256).Hash -ieq $want) { "OK - matches the published hash" }
+else { "STOP - it does not match. Do not run it." }
+```
+
+**2 · Run it.** Setup deploys a different add-in binary for each Revit year installed on the machine, plus the MCP server, and then completes Claude Code / Codex registration itself — waiting for an open client to close rather than editing its configuration underneath it. It never removes your other MCP entries.
+
+**3 · Start Revit and check.** A **Horizun Hub** tab appears in the ribbon once a document is open; its *Estado del puente* button answers "is this working, and which version?" without leaving Revit. From your MCP client, `horizun_health` answers the same with the commit included.
+
+Prefer one paste? This selects the latest release, downloads the setup and `SHA256SUMS.txt` from that same release, verifies the complete SHA-256, installs quietly and finishes client registration:
+
+```powershell
+irm https://raw.githubusercontent.com/HorizunGroup/horizun-revit-mcp/main/install-release.ps1 | iex
+```
+
+> **Publisher warning.** Releases before 1.0.0 may be published **without a publicly trusted code-signing certificate**. When that is the case, Windows SmartScreen and Revit warn about an unknown publisher — that is expected, and the SHA-256 check above is how you verify the download instead. Public signing becomes a mandatory release gate at 1.0.0; see the [code signing policy](https://github.com/HorizunGroup/horizun-revit-mcp/blob/main/CODE-SIGNING-POLICY.md).
+
+**Also in this release:** `manifest.json` (the exact payload), `package-hashes.json`, `sbom.json` (CycloneDX), and one `live-<year>.json` verification report per supported Revit year — this project promotes a build to stable only when a live report exists for every year, rather than on a local success claim.
+
+Everything else — what the tools do, what they refuse, the security model — is in the [README](https://github.com/HorizunGroup/horizun-revit-mcp#readme).
+
+---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,6 +803,38 @@ jobs:
             gh release create "$GITHUB_REF_NAME" "${files[@]}" --verify-tag --generate-notes --latest --title "Horizun Revit MCP $GITHUB_REF_NAME"
           fi
 
+      # THE RELEASE PAGE IS WHERE SOMEBODY WHO WANTS TO INSTALL ACTUALLY LANDS.
+      # --generate-notes alone leaves them a list of merged PRs and ten assets
+      # with no hint of which one to download, how to verify it, or why Windows
+      # is about to call the publisher unknown. The preamble goes ABOVE the
+      # generated changelog, and this step is idempotent: a re-run that finds it
+      # already there leaves the notes alone.
+      #
+      # Non-fatal on purpose. The binaries, their hashes and the live reports are
+      # the release; prose that failed to attach must not fail a publish that
+      # already succeeded - it must say so and let the job stand.
+      - name: Put the install instructions above the generated changelog
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          preamble='.github/release-preamble.md'
+          if [ ! -f "$preamble" ]; then
+            echo "::warning::$preamble is missing; the release keeps the generated notes only"
+            exit 0
+          fi
+          body=$(gh release view "$GITHUB_REF_NAME" --json body --jq .body) || {
+            echo "::warning::could not read the release notes back; leaving them as generated"; exit 0; }
+          case "$body" in
+            *'## Install'*) echo "install instructions already present; leaving the notes alone"; exit 0 ;;
+          esac
+          { cat "$preamble"; printf '\n'; printf '%s\n' "$body"; } > release-notes.md
+          gh release edit "$GITHUB_REF_NAME" --notes-file release-notes.md ||
+            echo "::warning::could not update the release notes; the assets are published and correct"
+
   publish-mcp-registry:
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'HorizunGroup/horizun-revit-mcp'
     needs: publish-stable-release

--- a/README.md
+++ b/README.md
@@ -71,9 +71,14 @@ Download `horizun-mcp-<version>-setup.exe` and `SHA256SUMS.txt` from the
 then check the hash before running anything:
 
 ```powershell
-Get-FileHash .\horizun-mcp-<version>-setup.exe -Algorithm SHA256
-Select-String -Path .\SHA256SUMS.txt -Pattern 'setup.exe'
+$exe  = Get-Item .\horizun-mcp-*-setup.exe
+$want = (Select-String -Path .\SHA256SUMS.txt -Pattern 'setup.exe').Line.Split(' ')[0]
+if ((Get-FileHash $exe -Algorithm SHA256).Hash -ieq $want) { "OK - matches the published hash" }
+else { "STOP - it does not match. Do not run it." }
 ```
+
+(`Get-FileHash` prints upper case and the file lists lower case, which is why the
+comparison above is case-insensitive rather than something to eyeball.)
 
 Every release also carries a payload `manifest.json`, `package-hashes.json`, an
 [SBOM](https://cyclonedx.org/) and one live verification report per supported


### PR DESCRIPTION
Walking the install path instead of reading it turned up two things.

### The hash check in the README did not survive contact with the real asset

It said: run `Get-FileHash`, run `Select-String`, compare. Downloading the real `horizun-mcp-0.9.0-setup.exe` (55 MB) shows the trap — `Get-FileHash` prints **upper case**, `SHA256SUMS.txt` lists **lower case**, so two identical hashes look different to the person checking. It is now one snippet that answers `OK` or `STOP`, and **the exact text published was executed against the downloaded release files** before being written down:

```
OK - matches the published hash
```

### The release page said nothing about installing

That page is where somebody who wants to install actually lands, and `--generate-notes` left them a list of merged pull requests above ten unexplained assets: no hint of which file to download, how to verify it, or why Windows is about to call the publisher unknown.

`.github/release-preamble.md` is that missing page — requirements, the verify step, what Setup does, the first Revit start, the one-paste alternative, the publisher warning, and what the other assets are for. It is **already applied to [v0.9.0](https://github.com/HorizunGroup/horizun-revit-mcp/releases/tag/v0.9.0)**, and this PR wires CI to prepend it above the generated changelog for every future tag, so the next release does not regress to bare notes.

That CI step is deliberately **idempotent** (a re-run that finds `## Install` already there leaves the notes alone) and **`continue-on-error`**: the binaries, their hashes and the live reports are the release, and prose that fails to attach must not fail a publish that already succeeded.

### Checks run here

- `scripts/public-consistency.tests.ps1` green
- the workflow still parses, and `publish-stable-release` keeps its steps in order
- the export ran its link-resolution pass and the sensitive-name scan (32 terms) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)