### PR TITLE
release: Horizun Revit MCP 0.9.6

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,7 +3,7 @@
     "name":  "io.github.HorizunGroup/horizun-revit-mcp",
     "title":  "Horizun Revit MCP",
     "description":  "Open-source MCP server for Autodesk Revit: typed BIM edits, families, exports and Power BI.",
-    "version":  "0.9.5",
+    "version":  "0.9.6",
     "repository":  {
                        "url":  "https://github.com/HorizunGroup/horizun-revit-mcp",
                        "source":  "github"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,9 +192,11 @@ and run `install.ps1` again.
   Save. A model that will not open unattended remains a finding either way.
 - **`horizun_execute_python` is disabled by default.** A fresh install uses
   `safe_write`: typed in-model writes are available, but arbitrary code is not.
-  The machine owner may use Revit's **Python ON/OFF** button for a 60-minute
-  grant, or the admin script `scripts/enable-execute-python.ps1` for a durable
-  developer opt-in; `-Disable` revokes it. Never edit settings to reverse the
+  A client may call `horizun_request_python_access` to show the question in Revit,
+  but only the machine owner can approve it. The **Python ON/OFF** button grants
+  persistent access until that same user revokes it; the admin script
+  `scripts/enable-execute-python.ps1` provides the same durable opt-in and
+  `-Disable` revokes it. Never edit settings to reverse the
   owner's choice. Compatible MCP clients refresh tools/list automatically after a
   change; restart once only when the client does not implement list-change notifications.
 - This bridge is **organisation-neutral by design**: no company's standards or
@@ -389,10 +391,12 @@ anterior: cierra Revit y vuelve a correr `install.ps1`.
   `with dialog_answer('dismiss'):` — alrededor de esa llamada y nada más, nunca de
   una corrida entera, porque Revit lee OK en el diálogo de cerrar-con-cambios como
   Guardar. Un modelo que no abre desatendido sigue siendo un hallazgo igual.
-- **`horizun_execute_python` viene deshabilitado por defecto.** El dueño de la
-  máquina puede habilitarlo durante 60 minutos con el botón **Python ON/OFF** de
-  Revit o administrarlo de forma durable con
-  `scripts/enable-execute-python.ps1`; `-Disable` revoca ambas rutas. Un
+- **`horizun_execute_python` viene deshabilitado por defecto.** Un cliente puede
+  llamar `horizun_request_python_access` para mostrar la solicitud en Revit, pero
+  solo el dueño de la máquina puede aprobarla. El botón **Python ON/OFF** concede
+  acceso persistente hasta que ese mismo usuario lo revoque; el script
+  `scripts/enable-execute-python.ps1` ofrece el mismo opt-in durable y `-Disable`
+  revoca ambas rutas. Un
   `enable_execute_python=false` explícito o un perfil por debajo de
   `unsafe_code` siempre se respeta, y no debes editar `settings.json` para
   revertirlo. Los clientes compatibles refrescan la lista automáticamente;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 What changed, and — where it matters — what was actually measured rather than
 assumed. Dates are the day the work landed.
 
+## v0.9.6 — 2026-08-20
+
+- **Persistent, owner-controlled Python permission.** Revit's **Python ON/OFF**
+  button now grants access until the machine owner explicitly turns it off,
+  instead of expiring after 60 minutes. The permission remains specific to
+  `horizun_execute_python`; read-only profiles, allowlists and denylists still
+  take precedence.
+- **Consent can be requested without sacrificing automation.** MCP clients can
+  call `horizun_request_python_access` to bring the consent prompt to Revit, but
+  they cannot approve it. Once the owner grants access, it remains available
+  across documents and compatible clients refresh their tool list automatically.
+- **Localized consent UI.** The ribbon dialog follows Revit's language: English
+  on English installations, Spanish on Spanish installations, with English as
+  the safe fallback.
+
 ## v0.9.5 — 2026-08-20
 
 - **Deep multi-agent hardening.** Typed plan execution now fails closed on

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- One product, one release number. The server and every Revit payload
          inherit this value and are packaged/deployed as an inseparable pair. -->
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ guessing.
 // horizun_health, abbreviated
 {
   "status": "healthy",
-  "horizun_version": "0.9.5",
+  "horizun_version": "0.9.6",
   "horizun_commit": "ced1aa1",
   "built_from_clean_tree": true,
   "revit_version": "2026",
@@ -324,10 +324,11 @@ respected — `read_only`, `safe_write`, `full_write` or
 `enable_execute_python: false` keep arbitrary code off, `allowed_tools` and
 `denied_tools` narrow any profile, and a settings file that exists but cannot be
 parsed falls **closed** (`read_only`, Python off) so a corrupted restriction
-never reads as consent. The **Python ON/OFF** button in Revit grants a visible
-60-minute exception without permanently elevating the profile; pressing it
-again revokes the permission immediately. `scripts/enable-execute-python.ps1`
-remains the explicit administrative path for a durable developer setup and
+never reads as consent. A client may call `horizun_request_python_access` to put
+the question visibly in Revit, but it cannot answer it. The machine owner can use
+the **Python ON/OFF** button to grant persistent access until that same user
+revokes it; pressing it again revokes the permission immediately.
+`scripts/enable-execute-python.ps1` remains the explicit administrative path and
 reverts with `-Disable`. The server emits `notifications/tools/list_changed` when
 the effective permission changes, so compatible clients update automatically;
 clients that ignore the notification need one restart.

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -120,7 +120,7 @@ re-read and lost-response replay for every product, including Horizun.
 | Axis | Strongest market evidence | Horizun position on 2026-08-20 | What remains |
 | --- | --- | --- | --- |
 | Vendor trust/support | Autodesk official server | Cannot honestly beat Autodesk on vendor identity or Revit entitlement support | Complement it; publish signed binaries and independent evidence |
-| Safe default | Autodesk read-oriented preview | Typed in-model writes available, Python and external/session effects off by default; Revit Python ON/OFF grant expires | Live adversarial proof and modeless approval history |
+| Safe default | Autodesk read-oriented preview | Typed in-model writes available, Python and external/session effects off by default; MCP may request but only the Revit user may persistently enable or revoke Python | Live adversarial proof and approval history |
 | Raw breadth/SOP library | Shuotao 173 tools / 76 SOPs | Lower raw count; broader verified verticals in family authoring, exports and Power BI | Versioned recipe/SOP marketplace, without compiling client standards into the bridge |
 | Version range | BIMwright 2022–2027 | 2023–2027 | Revit 2022 only if demand justifies a separately tested payload |
 | Atomic multi-step writes | KenLP documents one-transaction batches | `horizun_execute_plan`, dry-run, stale-plan binding, rollback trace and postcondition re-read | Publish common live fixtures against both products |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -27,7 +27,8 @@ and it is labelled as such everywhere it appears.
 | `horizun_save_document` | Save, then prove it: the file's timestamp and size before and after. On a workshared model it says, loudly, that this is not a synchronize. |
 | `horizun_relinquish_all` | Give back everything this user owns, and count what is still owned afterwards rather than assume zero. |
 | `horizun_capture_view` | Export a view and hand the IMAGE back, so the caller can look at the model instead of only reading it. |
-| `horizun_execute_python` | The execution fallback: Python against the whole API on the UI thread, stdlib included. **Disabled by default**. The owner may grant a 60-minute exception from the **Python ON/OFF** ribbon button, or configure a durable developer opt-in explicitly. `preflight=true` validates permission, document, size, hash and syntax without executing. Results are **self-reported, not host-verified**: the structured `__output__` contract classifies each run as `self_reported_verified`, `completed_unverified`, `partial` or `failed` — there is no `verified` state on this path, `host_verified` is always false, and a verified claim without evidence is downgraded. It detects an open transaction but cannot safely close or roll it back, and it has no typed command's dry-run, confirmation or post-commit guarantee. Long scripts arrive as `code_path` (a `.py` on this machine, decoded properly and named in tracebacks) instead of an inline string; what Revit raised comes back as `dialogs` and `failures` beside `__output__`, and `revit_raised(since)` reads the same record from inside the running script — which is how a batch learns that "Opening was canceled" was a dialog nobody was there to answer. |
+| `horizun_request_python_access` | Ask the machine owner visibly in Revit for persistent Python access. The MCP caller can show the question but cannot approve it, bypass the acknowledgement or queue it unattended. |
+| `horizun_execute_python` | The execution fallback: Python against the whole API on the UI thread, stdlib included. **Disabled by default**. The owner may grant persistent access from the **Python ON/OFF** ribbon button until that same user revokes it, or configure the same durable opt-in administratively. `preflight=true` validates permission, document, size, hash and syntax without executing. Results are **self-reported, not host-verified**: the structured `__output__` contract classifies each run as `self_reported_verified`, `completed_unverified`, `partial` or `failed` — there is no `verified` state on this path, `host_verified` is always false, and a verified claim without evidence is downgraded. It detects an open transaction but cannot safely close or roll it back, and it has no typed command's dry-run, confirmation or post-commit guarantee. Long scripts arrive as `code_path` (a `.py` on this machine, decoded properly and named in tracebacks) instead of an inline string; what Revit raised comes back as `dialogs` and `failures` beside `__output__`, and `revit_raised(since)` reads the same record from inside the running script — which is how a batch learns that "Opening was canceled" was a dialog nobody was there to answer. |
 | `horizun_model_scan` | The census, under the honesty contract. |
 | `horizun_write_params_verified` | Parameter writes, each re-read after commit. |
 | `horizun_delete_verified` | Deletion with the cascade counted, `dry_run` first. |
@@ -118,7 +119,8 @@ explicit administrative profile eligible for durable `horizun_execute_python`.
 what the bridge deliberately does not defend against, are in
 [security-model.md](security-model.md).
 
-The Revit ribbon's **Python ON/OFF** button grants a 60-minute exception without
-changing the profile and revokes it immediately on the next press. The server
+The MCP may call `horizun_request_python_access` to show the consent question,
+but only the person in Revit can answer it. The ribbon's **Python ON/OFF** button
+grants persistent access until that same user revokes it on the next press. The server
 announces the effective change with `notifications/tools/list_changed`; restart
 only clients that do not implement that standard notification.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -30,7 +30,8 @@ is a public release.
 - Separation between untrusted pull-request jobs, Revit integration runners and the
   signing runner, with immutable GitHub Actions references.
 - Safe capability defaults: typed in-model writes available, document/external side
-  effects gated, arbitrary Python off; a visible Revit ON/OFF grant expires.
+  effects gated, arbitrary Python off; a visible Revit ON/OFF grant remains active
+  only after explicit owner consent and until that owner revokes it.
 - Bounded queues, requests, responses, images, task records and retention stores.
 - MCP protocol negotiation through 2025-11-25 with Tools, Resources, Prompts,
   Completions, progress, opt-in Logging and durable task-augmented tool calls.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -54,10 +54,11 @@ the add-in on every use. `permission_profile` has four values:
 **The default is `safe_write`, with Python off.** A fresh install can use typed,
 verified writes inside the active document, but cannot change document sessions,
 write external files or execute arbitrary code. Elevation is an explicit owner
-decision. Revit's **Python ON/OFF** button may write a bounded
-`execute_python_ui_grant_until_utc`; it expires automatically without changing
-the underlying profile. A durable enable requires both `unsafe_code` and an
-explicit `enable_execute_python=true`. Changes are announced as
+decision. `horizun_request_python_access` may display the question inside Revit,
+but the MCP caller cannot answer it. Revit's **Python ON/OFF** button writes a
+persistent `execute_python_ui_granted=true` specific to Python; it does not
+elevate the underlying profile or enable other external/session tools. It remains
+active until that same Windows user revokes it. Changes are announced as
 `notifications/tools/list_changed`; this is a discovery convenience only, because
 both halves still re-check the permission on every call.
 
@@ -78,16 +79,16 @@ already read the models directly.
 
 `horizun_execute_python` runs arbitrary Python inside Revit on the UI thread. It
 is **disabled by default**. The preferred interactive grant is the Revit ribbon:
-the owner acknowledges the risk and enables it for 60 minutes, after which the
-grant fails closed. Pressing the button while enabled revokes both temporary and
-durable enable flags immediately. A durable developer machine can opt in with
+the owner acknowledges that the permission does not expire and enables it until
+they explicitly turn it off. Pressing the button while enabled revokes all enable
+flags immediately. A developer machine can make the same durable choice with
 `permission_profile=unsafe_code` plus `enable_execute_python=true`.
 
 Enabling it is a real widening of the exposed surface:
 an agent that reads untrusted content (a linked DWG, a PDF, an email) and holds
 this tool can be prompt-injected into running code with the signed-in user's
 rights. The compensating controls are the ones below, an explicit human grant,
-automatic expiry and the independent far-end gate.
+a persistent visible ON/OFF state, immediate owner revocation and the independent far-end gate.
 
 Gated in **both halves**: when disabled, the server does not advertise it and
 refuses it if called anyway; the add-in refuses it independently. The two ship
@@ -344,7 +345,7 @@ replace it.
 ## 9. Known gaps, stated
 
 - Arbitrary Python remains an explicit privileged bypass (§3), but is off by
-  default and temporary ribbon grants expire automatically.
+  default and a client can request—but never approve—the persistent ribbon grant.
 - The shipped Python standard library has deterministic file/hash and static-risk
   triage, but not a comprehensive semantic audit or Python-specific vulnerability
   feed. A clean scan is evidence for its explicit rules, not a safety guarantee.

--- a/scripts/enable-execute-python.ps1
+++ b/scripts/enable-execute-python.ps1
@@ -4,8 +4,9 @@
 
   execute_python runs arbitrary code inside Revit with the full API and the
   rights of the signed-in user. It is DISABLED BY DEFAULT. The preferred
-  interactive path is Revit's Python ON/OFF button, whose grant expires after
-  60 minutes. This script exists for durable developer administration:
+  interactive path is Revit's Python ON/OFF button, whose owner-approved grant
+  remains active until that same user revokes it. This script provides the same
+  durable choice for explicit administration:
 
     - ENABLE a machine deliberately with unsafe_code plus an explicit true.
     - DISABLE it deliberately with -Disable; an explicit false always wins.
@@ -156,11 +157,15 @@ try {
     $settings = Read-Settings $settingsPath
     if ($Disable) {
         $settings['enable_execute_python'] = $false
+        $settings.Remove('execute_python_ui_granted')
         $settings.Remove('execute_python_ui_grant_until_utc')
+        $settings.Remove('execute_python_ui_granted_at_utc')
     } else {
         $settings['permission_profile']    = 'unsafe_code'
         $settings['enable_execute_python'] = $true
+        $settings.Remove('execute_python_ui_granted')
         $settings.Remove('execute_python_ui_grant_until_utc')
+        $settings.Remove('execute_python_ui_granted_at_utc')
     }
 
     if (-not (Test-Path -LiteralPath $root)) { New-Item -ItemType Directory -Force -Path $root | Out-Null }
@@ -189,11 +194,13 @@ try {
     # and no live temporary grant; checking only the first key was a false green.
     $check = (Get-Content -LiteralPath $settingsPath -Raw -Encoding UTF8) | ConvertFrom-Json
     $grantPresent = $null -ne $check.PSObject.Properties['execute_python_ui_grant_until_utc']
+    $persistentUiGrantPresent = $null -ne $check.PSObject.Properties['execute_python_ui_granted']
+    $uiMetadataPresent = $null -ne $check.PSObject.Properties['execute_python_ui_granted_at_utc']
     if ($Disable) {
-        if ($check.enable_execute_python -ne $false -or $grantPresent) {
-            throw 'Wrote the file but the durable switch or temporary grant did not read back as OFF.'
+        if ($check.enable_execute_python -ne $false -or $grantPresent -or $persistentUiGrantPresent -or $uiMetadataPresent) {
+            throw 'Wrote the file but the durable switch or UI grant metadata did not read back as OFF.'
         }
-    } elseif ($check.permission_profile -ne 'unsafe_code' -or $check.enable_execute_python -ne $true -or $grantPresent) {
+    } elseif ($check.permission_profile -ne 'unsafe_code' -or $check.enable_execute_python -ne $true -or $grantPresent -or $persistentUiGrantPresent -or $uiMetadataPresent) {
         throw 'Wrote the file but the durable unsafe-code opt-in did not read back exactly.'
     }
 }

--- a/scripts/python-permission.tests.ps1
+++ b/scripts/python-permission.tests.ps1
@@ -13,7 +13,7 @@ try {
     New-Item -ItemType Directory -Path $temp -Force | Out-Null
     $settingsPath = Join-Path $temp 'settings.json'
     [IO.File]::WriteAllText($settingsPath,
-        '{"permission_profile":"unsafe_code","enable_execute_python":true,"execute_python_ui_grant_until_utc":"2099-01-01T00:00:00Z","unrelated":42}',
+        '{"permission_profile":"unsafe_code","enable_execute_python":true,"execute_python_ui_granted":true,"execute_python_ui_grant_until_utc":"2099-01-01T00:00:00Z","execute_python_ui_granted_at_utc":"2026-01-01T00:00:00Z","unrelated":42}',
         (New-Object Text.UTF8Encoding($false)))
 
     # A different process owns the exact production mutex. The admin operation
@@ -58,6 +58,8 @@ try {
     $disabled = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
     Assert-True ($disabled.enable_execute_python -eq $false) 'durable Python switch was not disabled'
     Assert-True ($null -eq $disabled.PSObject.Properties['execute_python_ui_grant_until_utc']) 'temporary grant survived disable'
+    Assert-True ($null -eq $disabled.PSObject.Properties['execute_python_ui_granted']) 'persistent UI grant survived disable'
+    Assert-True ($null -eq $disabled.PSObject.Properties['execute_python_ui_granted_at_utc']) 'persistent UI metadata survived disable'
     Assert-True ($disabled.unrelated -eq 42) 'unrelated setting was not preserved'
 
     & $shell -NoProfile -File $admin -Yes -DataRoot $temp
@@ -66,6 +68,8 @@ try {
     Assert-True ($enabled.permission_profile -eq 'unsafe_code') 'durable enable did not select unsafe_code'
     Assert-True ($enabled.enable_execute_python -eq $true) 'durable enable did not set explicit true'
     Assert-True ($null -eq $enabled.PSObject.Properties['execute_python_ui_grant_until_utc']) 'durable enable left a temporary grant'
+    Assert-True ($null -eq $enabled.PSObject.Properties['execute_python_ui_granted']) 'admin enable left a persistent UI grant'
+    Assert-True ($null -eq $enabled.PSObject.Properties['execute_python_ui_granted_at_utc']) 'admin enable impersonated a Revit UI grant'
     Assert-True ($enabled.unrelated -eq 42) 'durable enable lost unrelated settings'
 
     Write-Host '[PASS] Python permission administration is inter-process serialized, reversible and preserving' -ForegroundColor Green

--- a/scripts/verify-live.ps1
+++ b/scripts/verify-live.ps1
@@ -202,8 +202,17 @@ if (Test-Path $Fixtures) {
 if ([string]::IsNullOrWhiteSpace($FamilyTemplate)) {
     $templateRoot = Join-Path $env:ProgramData ("Autodesk\RVT {0}\Family Templates" -f $Year)
     if (Test-Path $templateRoot) {
-        $candidateTemplate = Get-ChildItem -LiteralPath $templateRoot -Recurse -Filter '*.rft' -File -ErrorAction SilentlyContinue |
+        # Prefer an ASCII path. Some older Revit generations report localized
+        # template paths as "illegal characters" through NewFamilyDocument even
+        # though Windows itself can open them; this probe is about the typed plan,
+        # not localization support.
+        $templates = @(Get-ChildItem -LiteralPath $templateRoot -Recurse -Filter '*.rft' -File -ErrorAction SilentlyContinue)
+        $candidateTemplate = $templates |
+                             Where-Object { $_.FullName -cmatch '^[\x20-\x7E]+$' } |
                              Sort-Object FullName | Select-Object -First 1
+        if (-not $candidateTemplate) {
+            $candidateTemplate = $templates | Sort-Object FullName | Select-Object -First 1
+        }
         if ($candidateTemplate) {
             $FamilyTemplate = $candidateTemplate.FullName
             $fixtureSource['FamilyTemplate'] = 'auto-discovered'
@@ -2431,7 +2440,8 @@ if (-not $Document) {
 # as "it behaves this way against a running Revit".
 #
 # execute_python is disabled by DEFAULT. This harness never grants the privilege:
-# it reports the gap. The owner may use Revit's expiring Python ON/OFF button or
+# it reports the gap. A client may request the visible dialog, but only the owner
+# may approve persistent access with Revit's Python ON/OFF button or
 # scripts/enable-execute-python.ps1 and then re-run.
 if (-not ($listed | Where-Object { $_.name -eq 'horizun_execute_python' })) {
     $notCovered += 'the execute_python fallback surface - the typed-overlap advisory, preflight, and the ' +

--- a/src/Horizun.Contracts/Contract.cs
+++ b/src/Horizun.Contracts/Contract.cs
@@ -770,7 +770,8 @@ namespace Horizun.Contracts
                 Name = "horizun_submit_job",
                 Command = "horizun_submit_job",
                 Description =
-                    "Submit any installed Revit-side tool except execute_python or submit_job itself to the bounded " +
+                    "Submit any installed Revit-side tool except execute_python, request_python_access or " +
+                    "submit_job itself to the bounded " +
                     "asynchronous queue and return a persistent job_id immediately. The submission is durably " +
                     "idempotent, queued work alternates fairly with interactive calls, permissions are checked " +
                     "again when execution begins, and horizun_job_status exposes queued/running/result/failure or " +
@@ -778,7 +779,7 @@ namespace Horizun.Contracts
                 InputSchema = JObject.Parse(@"{
   ""type"": ""object"", ""required"": [""tool"", ""arguments""],
   ""properties"": {
-    ""tool"": { ""type"": ""string"", ""description"": ""An installed Revit-side MCP tool. Host-only tools, horizun_execute_python and horizun_submit_job are refused."" },
+    ""tool"": { ""type"": ""string"", ""description"": ""An installed Revit-side MCP tool. Host-only tools, horizun_execute_python, horizun_request_python_access and horizun_submit_job are refused."" },
     ""arguments"": { ""type"": ""object"", ""description"": ""The exact typed arguments, including target_document, dry_run/confirmation_token where that tool requires them."" },
     ""retain_until_utc"": { ""type"": ""string"", ""format"": ""date-time"", ""description"": ""Optional durable-retention lease for MCP Tasks. Must be a future UTC instant no more than seven days away; it protects this job record from configured retention but does not extend execution."" }
   }, ""additionalProperties"": false
@@ -822,12 +823,34 @@ namespace Horizun.Contracts
             },
             new CommandContract
             {
+                Name = "horizun_request_python_access",
+                Command = "horizun_request_python_access",
+                Description =
+                    "REQUEST, NEVER SELF-GRANT, persistent arbitrary-Python permission. Opens a visible consent " +
+                    "dialog inside Revit and waits for the machine owner to approve or reject it. Approval is " +
+                    "indefinite across files, batches and Revit restarts until that Windows user turns Python " +
+                    "OFF from the ribbon or the administrator -Disable command. The MCP caller cannot press the " +
+                    "button, cannot bypass the acknowledgement and cannot disable the owner's refusal. Do not " +
+                    "call this when nobody is at the Revit keyboard.",
+                InputSchema = JObject.Parse(@"{
+  ""type"": ""object"",
+  ""properties"": {
+    ""reason"": { ""type"": ""string"", ""maxLength"": 500,
+      ""description"": ""Optional human-readable reason shown as UNVERIFIED caller text in the Revit consent dialog. It never grants permission."" }
+  },
+  ""additionalProperties"": false
+}")
+            },
+            new CommandContract
+            {
                 Name = "horizun_execute_python",
                 Command = "horizun_execute_python",
                 Description =
                     "Run Python directly against the Revit API on the UI thread - THE EXECUTION FALLBACK for " +
                     "everything the typed commands do not cover. Disabled by default; the machine owner must " +
-                    "explicitly grant unsafe_code plus enable_execute_python, optionally until a UTC expiry. " +
+                    "explicitly approve the persistent Revit UI grant, or configure unsafe_code plus " +
+                    "enable_execute_python administratively. It remains enabled until that Windows user revokes " +
+                    "it; the MCP client cannot grant itself permission. " +
                     "POLICY: prefer a typed command when it fully covers the " +
                     "operation. When none exists, or a failed typed call returns fallback.allowed=true - its " +
                     "machine-readable signal that no typed capability covers the request AND nothing was " +
@@ -1814,7 +1837,7 @@ namespace Horizun.Contracts
             // read_only has to keep horizun_target or it cannot choose the Revit it reads.
             var hostState = new HashSet<string>(StringComparer.Ordinal)
             {
-                "horizun_navigate", "horizun_target"
+                "horizun_navigate", "horizun_target", "horizun_request_python_access"
             };
 
             // MCP's destructiveHint, where every other classification already lives.

--- a/src/Horizun.Revit/App.cs
+++ b/src/Horizun.Revit/App.cs
@@ -116,6 +116,7 @@ namespace Horizun.Revit
         private static void RegisterCommands(Dispatcher d)
         {
             d.Register(new GetDocumentInfoCommand());
+            d.Register(new RequestPythonAccessCommand());
             d.Register(new ExecutePythonCommand());
             d.Register(new ModelScanCommand());
             d.Register(new WriteParamsCommand());

--- a/src/Horizun.Revit/Commands/ExecutePythonCommand.cs
+++ b/src/Horizun.Revit/Commands/ExecutePythonCommand.cs
@@ -5,8 +5,8 @@
 // no set of typed tools ever covers the whole API, this does.
 //
 // DISABLED BY DEFAULT: when a typed command cannot cover a request, the owner may
-// grant a bounded exception from Revit's Python ON/OFF button, or configure a
-// durable developer opt-in. It runs arbitrary code inside Revit with the full API
+// grant persistent access from Revit's Python ON/OFF button until they revoke it,
+// or configure the same durable opt-in administratively. It runs arbitrary code inside Revit with the full API
 // and the rights of the signed-in user, so the per-machine switch is checked here
 // AND in the server, because the two halves ship separately and neither may be
 // the only gate.

--- a/src/Horizun.Revit/Commands/RequestPythonAccessCommand.cs
+++ b/src/Horizun.Revit/Commands/RequestPythonAccessCommand.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------------
+// Horizun MCP — request, never self-grant, arbitrary Python permission.
+// -----------------------------------------------------------------------------
+using System;
+using Autodesk.Revit.UI;
+using Horizun.Contracts;
+using Horizun.Revit;
+using Horizun.Revit.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Horizun.Revit.Commands
+{
+    /// <summary>
+    /// Opens the same owner-controlled consent UI as the ribbon. The MCP caller can
+    /// bring the question to the person in Revit, but it cannot answer the question or
+    /// write the privilege itself. This command must remain synchronous: queueing a
+    /// surprise permission dialog for later would sever the request from its human.
+    /// </summary>
+    public sealed class RequestPythonAccessCommand : ICommand
+    {
+        public string Name => "horizun_request_python_access";
+
+        public string Description =>
+            "Ask the machine owner in Revit to enable persistent arbitrary Python. The caller cannot grant " +
+            "permission; it waits for the visible human decision. Do not call this unattended.";
+
+        public CommandResult Execute(UIApplication app, string paramsJson)
+        {
+            JObject request;
+            try { request = string.IsNullOrWhiteSpace(paramsJson) ? new JObject() : JObject.Parse(paramsJson); }
+            catch (JsonException ex) { return CommandResult.Fail("Parameters must be a JSON object: " + ex.Message); }
+
+            string reason = request.Value<string>("reason");
+            if (reason != null && reason.Length > 500)
+                return CommandResult.Fail("reason is limited to 500 characters. No dialog was shown.");
+
+            CommandContract python = Contract.Find("horizun_execute_python");
+            if (Settings.IsToolAllowed(python, out string refusal))
+            {
+                return CommandResult.Ok(new JObject
+                {
+                    ["granted"] = true,
+                    ["decision"] = "already_enabled",
+                    ["persistent"] = true,
+                    ["expires_at"] = JValue.CreateNull(),
+                    ["what_this_means"] = "Python was already ON. No consent dialog was needed."
+                });
+            }
+
+            string message = null;
+            bool spanish = PythonPermissionCommand.IsSpanishLanguage(app.Application.Language);
+            Result decision = PythonPermissionCommand.Enable(ref message, refusal, reason, spanish);
+            if (decision == Result.Failed)
+                return CommandResult.Fail(string.IsNullOrWhiteSpace(message)
+                    ? "The owner permission update failed. Python remains OFF."
+                    : message + " Python remains OFF.");
+
+            bool granted = decision == Result.Succeeded && Settings.IsToolAllowed(python, out _);
+            return CommandResult.Ok(new JObject
+            {
+                ["granted"] = granted,
+                ["decision"] = granted ? "enabled_by_owner" : "rejected_or_cancelled_by_owner",
+                ["persistent"] = granted,
+                ["expires_at"] = JValue.CreateNull(),
+                ["what_this_means"] = granted
+                    ? "The person in Revit enabled Python. It remains ON until that Windows user disables it."
+                    : "The person in Revit did not grant permission. Python remains OFF; do not retry or bypass their choice."
+            });
+        }
+    }
+}

--- a/src/Horizun.Revit/Commands/SubmitJobCommand.cs
+++ b/src/Horizun.Revit/Commands/SubmitJobCommand.cs
@@ -27,7 +27,8 @@ namespace Horizun.Revit.Commands
             if (string.IsNullOrWhiteSpace(tool)) return CommandResult.Fail("tool is required. Nothing was queued.");
             if (arguments == null) return CommandResult.Fail("arguments must be an object. Nothing was queued.");
             if (string.Equals(tool, Name, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(tool, "horizun_execute_python", StringComparison.OrdinalIgnoreCase))
+                string.Equals(tool, "horizun_execute_python", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(tool, "horizun_request_python_access", StringComparison.OrdinalIgnoreCase))
                 return CommandResult.Fail("'" + tool + "' cannot be submitted through this generic queue. Nothing was queued.");
             ICommand command = _resolve(tool);
             CommandContract contract = Contract.Find(tool);

--- a/src/Horizun.Revit/Core/Interference.cs
+++ b/src/Horizun.Revit/Core/Interference.cs
@@ -171,7 +171,14 @@ namespace Horizun.Revit.Core
             string answered;
             try
             {
-                if (_openDialogPolicy == DialogAnswer.Dismiss)
+                if (_openDialogPolicy == DialogAnswer.Human)
+                {
+                    // Exactly one compiled command uses this: the Python permission
+                    // request. Do not call OverrideResult at all; the person in Revit is
+                    // the security boundary and must make the decision themselves.
+                    answered = "left open for the machine owner to answer; the bridge did not choose";
+                }
+                else if (_openDialogPolicy == DialogAnswer.Dismiss)
                 {
                     // on_open_dialog=dismiss: acknowledge and continue. 1 == IDOK for a
                     // plain dialog box; TaskDialogResult.Ok is 1 too. Best effort - a

--- a/src/Horizun.Revit/Core/OpenDialogPolicy.cs
+++ b/src/Horizun.Revit/Core/OpenDialogPolicy.cs
@@ -15,7 +15,16 @@ namespace Horizun.Revit.Core
     /// dialog whose only unattended answer is "acknowledge and continue" - 6 of 123
     /// models in one batch could not be audited for want of it.
     /// </summary>
-    public enum DialogAnswer { Cancel, Dismiss }
+    public enum DialogAnswer
+    {
+        Cancel,
+        Dismiss,
+
+        // Never accepted from an MCP argument. Compiled Horizun consent UI uses this
+        // internal policy so the global dialog watcher observes the prompt without
+        // answering it on the machine owner's behalf.
+        Human
+    }
 
     public static class OpenDialogPolicy
     {

--- a/src/Horizun.Revit/Core/Settings.cs
+++ b/src/Horizun.Revit/Core/Settings.cs
@@ -81,8 +81,10 @@ namespace Horizun.Revit.Core
         /// It runs arbitrary code inside Revit, on the UI thread, with full API access
         /// and the rights of the signed-in user. Enabling it requires an explicit true
         /// AND permission_profile=unsafe_code. An absent or non-boolean key means OFF.
-        /// A separate execute_python_ui_grant_until_utc written by Revit may grant a
-        /// bounded exception without leaving standing consent.
+        /// The Revit ribbon writes a separate persistent UI grant which authorizes only
+        /// this tool and does not silently elevate the rest of permission_profile.
+        /// A legacy execute_python_ui_grant_until_utc is still honoured until its old
+        /// expiry so an in-place upgrade never revokes an already-approved running batch.
         /// </summary>
         public static bool ExecutePythonEnabled
         {
@@ -92,15 +94,17 @@ namespace Horizun.Revit.Core
                 JObject o = Read(out state);
                 if (state == FileState.Malformed) return false;
                 if (TemporaryExecutePythonGrant(o, DateTimeOffset.UtcNow, out _)) return true;
+                JToken ui = o?["execute_python_ui_granted"];
+                if (ui != null && ui.Type == JTokenType.Boolean && (bool)ui) return true;
                 JToken t = o?["enable_execute_python"];
                 return t != null && t.Type == JTokenType.Boolean && (bool)t;
             }
         }
 
         /// <summary>
-        /// Active human grant written by the Revit ribbon. Unlike the durable admin
-        /// switch it does not change permission_profile and therefore cannot leave the
-        /// machine elevated after expiry.
+        /// Legacy bounded grant written by versions before the ribbon became a persistent
+        /// owner switch. New code never creates this key; it is read only for a safe
+        /// in-place upgrade and removed by either ON or OFF.
         /// </summary>
         public static DateTimeOffset? ExecutePythonTemporaryGrantUntilUtc
         {
@@ -143,9 +147,13 @@ namespace Horizun.Revit.Core
             { reason = contract.Name + " is outside the allowed_tools allowlist in " + Path() + "."; return false; }
 
             string profile = PermissionProfile;
-            bool temporaryPythonGrant = contract.Name == "horizun_execute_python" &&
-                                        profile != "read_only" &&
-                                        ExecutePythonTemporaryGrantUntilUtc != null;
+            JToken persistentUiToken = settings?["execute_python_ui_granted"];
+            bool persistentUiGrant = persistentUiToken != null &&
+                                     persistentUiToken.Type == JTokenType.Boolean &&
+                                     (bool)persistentUiToken;
+            bool humanPythonGrant = contract.Name == "horizun_execute_python" &&
+                                    profile != "read_only" &&
+                                    (persistentUiGrant || ExecutePythonTemporaryGrantUntilUtc != null);
 
             // ExternalSideEffect is consulted by BOTH restrictive profiles, and that is
             // the fix rather than a detail. The classification exists precisely to mean
@@ -154,7 +162,7 @@ namespace Horizun.Revit.Core
             // is one: a machine set to read_only refused to move a wall and then rewrote
             // a workbook on disk. Deciding on the ENUM rather than on a list of names is
             // what keeps the next externally-effecting tool from repeating it.
-            if (!temporaryPythonGrant && profile == "read_only" &&
+            if (!humanPythonGrant && profile == "read_only" &&
                 (contract.Effect == ToolEffect.Mutating || contract.Effect == ToolEffect.MutatingUnlessDryRun ||
                  contract.Effect == ToolEffect.DocumentSession || contract.Effect == ToolEffect.ExternalSideEffect))
             {
@@ -163,7 +171,7 @@ namespace Horizun.Revit.Core
                          "written outside it.";
                 return false;
             }
-            if (!temporaryPythonGrant && profile == "safe_write" &&
+            if (!humanPythonGrant && profile == "safe_write" &&
                 (contract.Effect == ToolEffect.DocumentSession || contract.Effect == ToolEffect.ExternalSideEffect ||
                  // Named as well as classified: these write outside the model while being
                  // classified MutatingUnlessDryRun, so the effect alone does not catch them.
@@ -178,13 +186,13 @@ namespace Horizun.Revit.Core
                 return false;
             }
             if (contract.Name == "horizun_execute_python" &&
-                (!temporaryPythonGrant &&
+                (!humanPythonGrant &&
                  (profile != "unsafe_code" || !ExecutePythonEnabled)))
             {
                 reason = "horizun_execute_python requires explicit permission_profile=unsafe_code and " +
-                         "enable_execute_python=true in " + Path() + ", OR a still-active temporary grant made " +
-                         "from the Revit ribbon. It is OFF on a fresh install. Only the machine's owner may " +
-                         "grant or renew that privilege.";
+                         "enable_execute_python=true in " + Path() + ", OR a persistent owner grant made from " +
+                         "Revit's Python ON/OFF button. It is OFF on a fresh install. Only the machine's owner " +
+                         "may grant that privilege, and it remains OFF until that owner does so.";
                 return false;
             }
             return true;
@@ -199,7 +207,8 @@ namespace Horizun.Revit.Core
             return "horizun_execute_python is DISABLED ON THIS MACHINE. This is the safe default: arbitrary " +
                    "code requires explicit owner consent in " + Path() + ". Respect the choice: do not edit the " +
                    "file yourself. If the MACHINE'S OWNER needs the developer escape hatch, they can grant a " +
-                   "time-limited or durable opt-in with scripts/enable-execute-python.ps1; -Disable revokes it. " +
+                   "persistent opt-in from Revit's Python ON/OFF button or with " +
+                   "scripts/enable-execute-python.ps1; -Disable revokes it. " +
                    "The add-in re-reads settings on every call, and the server announces a standard " +
                    "tools/list_changed notification. If a client does not implement that notification, restart " +
                    "it once for the tool to appear. Meanwhile, use typed commands: they cover most operations " +
@@ -207,26 +216,19 @@ namespace Horizun.Revit.Core
         }
 
         /// <summary>
-        /// Grant arbitrary Python from an explicit Revit UI action. The grant is bounded
-        /// to four hours even if a caller passes a larger duration; the ribbon currently
-        /// asks for one hour. The durable administrator switch is deliberately untouched.
+        /// Grant arbitrary Python from an explicit human action inside Revit. This is a
+        /// durable owner switch and remains enabled until that same Windows user revokes
+        /// it. It authorizes only execute_python; it deliberately does not elevate the
+        /// underlying profile or enable other external/session tools. The old expiring UI
+        /// key is removed so there is one unambiguous source of truth after the decision.
         /// </summary>
-        public static bool TryGrantExecutePythonTemporarily(
-            TimeSpan duration, out DateTimeOffset untilUtc, out string error)
+        public static bool TryGrantExecutePythonPersistently(out string error)
         {
-            untilUtc = default(DateTimeOffset);
-            error = null;
-            if (duration <= TimeSpan.Zero || duration > TimeSpan.FromHours(4))
-            {
-                error = "The temporary Python grant must be greater than zero and no longer than four hours.";
-                return false;
-            }
-
-            DateTimeOffset requestedUntil = DateTimeOffset.UtcNow.Add(duration);
-            untilUtc = requestedUntil;
             return TryUpdate(o =>
             {
-                o["execute_python_ui_grant_until_utc"] = requestedUntil.ToString("O");
+                o["execute_python_ui_granted"] = true;
+                o["execute_python_ui_granted_at_utc"] = DateTimeOffset.UtcNow.ToString("O");
+                o.Remove("execute_python_ui_grant_until_utc");
                 return true;
             }, out error);
         }
@@ -242,16 +244,9 @@ namespace Horizun.Revit.Core
             return TryUpdate(o =>
             {
                 o["enable_execute_python"] = false;
+                o.Remove("execute_python_ui_granted");
                 o.Remove("execute_python_ui_grant_until_utc");
-                return true;
-            }, out error);
-        }
-
-        public static bool TryClearExecutePythonTemporaryGrant(out string error)
-        {
-            return TryUpdate(o =>
-            {
-                o.Remove("execute_python_ui_grant_until_utc");
+                o.Remove("execute_python_ui_granted_at_utc");
                 return true;
             }, out error);
         }

--- a/src/Horizun.Revit/Ribbon.cs
+++ b/src/Horizun.Revit/Ribbon.cs
@@ -13,7 +13,7 @@
 // So: one tab, one panel, three buttons. STATUS answers the support question
 // without leaving Revit — loaded, which version, which commit, is the bridge
 // listening, where is the log. PYTHON makes arbitrary-code consent a local,
-// visible, expiring human action. HUB is where the layer above this one lives.
+// visible, persistent human action. HUB is where the layer above this one lives.
 //
 // A ribbon must never be the reason Revit fails to start: everything here is
 // wrapped, and a failure is logged and swallowed. The bridge does not depend on
@@ -53,6 +53,7 @@ namespace Horizun.Revit
 
             RibbonPanel panel = app.CreateRibbonPanel(TabName, PanelName);
             string asm = Assembly.GetExecutingAssembly().Location;
+            bool spanish = PythonPermissionCommand.IsSpanishLanguage(app.ControlledApplication.Language);
 
             var status = new PushButtonData(
                 "HorizunBridgeStatus", "Estado\ndel puente", asm, typeof(BridgeStatusCommand).FullName)
@@ -77,11 +78,17 @@ namespace Horizun.Revit
             var python = new PushButtonData(
                 "HorizunPythonPermission", "Python\nON/OFF", asm, typeof(PythonPermissionCommand).FullName)
             {
-                ToolTip = "Activar temporalmente o revocar la ejecución Python",
-                LongDescription =
-                    "horizun_execute_python ejecuta código arbitrario con los permisos del usuario. Está " +
-                    "apagado por defecto. Este botón permite al dueño presente en Revit activarlo durante " +
-                    "60 minutos o revocarlo inmediatamente; nunca deja una elevación permanente implícita."
+                ToolTip = spanish
+                    ? "Activar persistentemente o revocar la ejecución Python"
+                    : "Persistently enable or revoke Python execution",
+                LongDescription = spanish
+                    ? "horizun_execute_python ejecuta código arbitrario con los permisos del usuario. Está " +
+                      "apagado por defecto. Este botón permite al dueño presente en Revit activarlo hasta que " +
+                      "él mismo lo desactive, o revocarlo inmediatamente. La activación nunca puede concedérsela " +
+                      "un cliente MCP por sí solo."
+                    : "horizun_execute_python runs arbitrary code with the user's Windows permissions. It is " +
+                      "off by default. This button lets the owner present in Revit enable it until they disable " +
+                      "it themselves, or revoke it immediately. An MCP client can never grant itself access."
             };
 
             AddImages(status, "status");
@@ -138,7 +145,8 @@ namespace Horizun.Revit
                         (Build.BuiltFromCleanTree ? "" : "  (árbol con cambios sin confirmar)") + "\n" +
                         "Revit: " + year + "\n\n" +
                         "Perfil: " + BridgeSettings.PermissionProfile + "\n" +
-                        PythonStatusLine() + "\n\n" +
+                        PythonStatusLine(PythonPermissionCommand.IsSpanishLanguage(
+                            data.Application.Application.Language)) + "\n\n" +
                         (published
                             ? "Descubrimiento: " + discovery + "\n\nUn cliente MCP que arranque ahora encontrará " +
                               "este Revit. Si aun así falla, casi siempre es que el servidor y el add-in vienen " +
@@ -173,14 +181,19 @@ namespace Horizun.Revit
             catch (Exception ex) { Log.Warn("could not open '" + target + "': " + ex.Message); }
         }
 
-        internal static string PythonStatusLine()
+        internal static string PythonStatusLine(bool spanish)
         {
             bool allowed = BridgeSettings.IsToolAllowed(Contract.Find("horizun_execute_python"), out _);
             DateTimeOffset? until = BridgeSettings.ExecutePythonTemporaryGrantUntilUtc;
             if (!allowed) return "Python: OFF";
             if (until != null)
-                return "Python: ON temporal hasta " + until.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
-            return "Python: ON por configuración administrativa";
+                return (spanish
+                    ? "Python: ON por un permiso temporal heredado hasta "
+                    : "Python: ON under a legacy temporary grant until ") +
+                    until.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
+            return spanish
+                ? "Python: ON persistente hasta que el usuario lo desactive"
+                : "Python: persistently ON until the user disables it";
         }
     }
 
@@ -192,8 +205,9 @@ namespace Horizun.Revit
             try
             {
                 bool allowed = BridgeSettings.IsToolAllowed(Contract.Find("horizun_execute_python"), out string refusal);
-                if (allowed) return Disable(ref message);
-                return Enable(ref message, refusal);
+                bool spanish = IsSpanishLanguage(data.Application.Application.Language);
+                if (allowed) return Disable(ref message, spanish);
+                return Enable(ref message, refusal, null, spanish);
             }
             catch (Exception ex)
             {
@@ -202,79 +216,122 @@ namespace Horizun.Revit
             }
         }
 
-        private static Result Enable(ref string message, string currentRefusal)
+        internal static Result Enable(
+            ref string message, string currentRefusal, string requestReason, bool spanish)
         {
-            var dialog = new TaskDialog("Horizun — permiso Python")
+            string title = spanish ? "Horizun — permiso Python" : "Horizun — Python permission";
+            var dialog = new TaskDialog(title)
             {
-                MainInstruction = "Python está OFF.",
-                MainContent =
-                    "Activarlo permite que un cliente MCP ejecute código arbitrario dentro de Revit con sus " +
-                    "permisos de Windows. Las herramientas tipadas verifican sus cambios; Python no puede " +
-                    "ofrecer esa garantía.\n\nLa autorización expirará automáticamente en 60 minutos. " +
-                    "Los clientes MCP compatibles refrescan tools/list automáticamente. Si el suyo no lo hace, " +
-                    "reinícielo una vez.",
-                ExpandedContent = currentRefusal ?? "",
+                MainInstruction = spanish ? "Python está OFF." : "Python is OFF.",
+                MainContent = spanish
+                    ? "Activarlo permite que un cliente MCP ejecute código arbitrario dentro de Revit con sus " +
+                      "permisos de Windows. Las herramientas tipadas verifican sus cambios; Python no puede " +
+                      "ofrecer esa garantía.\n\nLa autorización NO EXPIRA: permanecerá activa entre archivos, " +
+                      "lotes y reinicios de Revit hasta que este usuario la desactive manualmente. " +
+                      "Los clientes MCP compatibles refrescan tools/list automáticamente. Si el suyo no lo hace, " +
+                      "reinícielo una vez."
+                    : "Enabling it allows an MCP client to run arbitrary code inside Revit with your Windows " +
+                      "permissions. Typed tools verify their changes; Python cannot provide that guarantee.\n\n" +
+                      "This permission DOES NOT EXPIRE: it remains active across files, batches and Revit " +
+                      "restarts until this user manually disables it. Compatible MCP clients refresh tools/list " +
+                      "automatically. If yours does not, restart it once.",
+                ExpandedContent =
+                    (string.IsNullOrWhiteSpace(requestReason)
+                        ? ""
+                        : (spanish
+                            ? "Solicitud declarada por el cliente MCP (texto no verificado):\n"
+                            : "Reason declared by the MCP client (unverified text):\n") + requestReason + "\n\n") +
+                    (currentRefusal ?? ""),
                 CommonButtons = TaskDialogCommonButtons.Cancel,
-                VerificationText = "Entiendo que esta capacidad ejecuta código arbitrario"
+                VerificationText = spanish
+                    ? "Entiendo que ejecuta código arbitrario y permanecerá activo hasta que yo lo desactive"
+                    : "I understand this runs arbitrary code and remains active until I disable it"
             };
-            dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Activar Python durante 60 minutos");
-            TaskDialogResult choice = dialog.Show();
+            dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
+                spanish ? "Activar Python hasta que yo lo desactive" : "Enable Python until I disable it");
+            TaskDialogResult choice = ShowForHuman(dialog);
             if (choice != TaskDialogResult.CommandLink1) return Result.Cancelled;
             if (!dialog.WasVerificationChecked())
             {
-                TaskDialog.Show("Horizun — permiso Python",
-                    "No se activó. Marque la casilla de comprensión para conceder el permiso.");
+                ShowForHuman(title, spanish
+                    ? "No se activó. Marque la casilla de comprensión para conceder el permiso."
+                    : "Python was not enabled. Check the acknowledgement box to grant permission.");
                 return Result.Cancelled;
             }
 
-            if (!BridgeSettings.TryGrantExecutePythonTemporarily(
-                    TimeSpan.FromMinutes(60), out DateTimeOffset until, out string error))
+            if (!BridgeSettings.TryGrantExecutePythonPersistently(out string error))
             {
                 message = error;
-                TaskDialog.Show("Horizun — permiso Python", error);
+                ShowForHuman(title, error);
                 return Result.Failed;
             }
 
             if (!BridgeSettings.IsToolAllowed(Contract.Find("horizun_execute_python"), out string stillRefused))
             {
-                BridgeSettings.TryClearExecutePythonTemporaryGrant(out _);
+                BridgeSettings.TryRevokeExecutePython(out _);
                 message = stillRefused;
-                TaskDialog.Show("Horizun — permiso Python",
-                    "No se activó porque otra política de la máquina lo prohíbe:\n\n" + stillRefused);
+                ShowForHuman(title, (spanish
+                    ? "No se activó porque otra política de la máquina lo prohíbe:\n\n"
+                    : "Python was not enabled because another machine policy prohibits it:\n\n") + stillRefused);
                 return Result.Failed;
             }
 
-            TaskDialog.Show("Horizun — permiso Python",
-                "Python está ON hasta " + until.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz") +
-                ".\n\nLos clientes compatibles actualizarán la herramienta automáticamente; si el suyo " +
-                "no lo hace, reinícielo una vez.");
+            ShowForHuman(title, spanish
+                ? "Python está ON de forma persistente. Permanecerá activo hasta que este usuario lo desactive " +
+                  "desde el botón Python ON/OFF o con el comando administrativo -Disable.\n\nLos clientes " +
+                  "compatibles actualizarán la herramienta automáticamente; si el suyo no lo hace, reinícielo una vez."
+                : "Python is persistently ON. It remains active until this user disables it from the Python " +
+                  "ON/OFF button or with the administrative -Disable command.\n\nCompatible clients update the " +
+                  "tool automatically; if yours does not, restart it once.");
             return Result.Succeeded;
         }
 
-        private static Result Disable(ref string message)
+        private static TaskDialogResult ShowForHuman(TaskDialog dialog)
         {
-            var dialog = new TaskDialog("Horizun — permiso Python")
+            // Calls originating in MCP run under the global dialog watcher. Its normal
+            // fail-safe answer is Cancel; this narrowly scoped policy tells it to observe
+            // this consent UI but never answer it for the human.
+            using (Interference.WithDialogAnswer(DialogAnswer.Human)) return dialog.Show();
+        }
+
+        private static void ShowForHuman(string title, string content)
+        {
+            using (Interference.WithDialogAnswer(DialogAnswer.Human)) TaskDialog.Show(title, content);
+        }
+
+        private static Result Disable(ref string message, bool spanish)
+        {
+            string title = spanish ? "Horizun — permiso Python" : "Horizun — Python permission";
+            var dialog = new TaskDialog(title)
             {
-                MainInstruction = "Python está ON.",
-                MainContent = BridgeStatusCommand.PythonStatusLine() +
-                    "\n\nDesactivarlo se aplica a la siguiente llamada incluso si el cliente MCP todavía " +
-                    "muestra la herramienta.",
+                MainInstruction = spanish ? "Python está ON." : "Python is ON.",
+                MainContent = BridgeStatusCommand.PythonStatusLine(spanish) +
+                    (spanish
+                        ? "\n\nDesactivarlo se aplica a la siguiente llamada incluso si el cliente MCP todavía muestra la herramienta."
+                        : "\n\nDisabling it applies to the next call even if the MCP client still displays the tool."),
                 CommonButtons = TaskDialogCommonButtons.Cancel
             };
-            dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Desactivar Python ahora");
+            dialog.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
+                spanish ? "Desactivar Python ahora" : "Disable Python now");
             if (dialog.Show() != TaskDialogResult.CommandLink1) return Result.Cancelled;
 
             if (!BridgeSettings.TryRevokeExecutePython(out string error))
             {
                 message = error;
-                TaskDialog.Show("Horizun — permiso Python", error);
+                TaskDialog.Show(title, error);
                 return Result.Failed;
             }
 
-            TaskDialog.Show("Horizun — permiso Python",
-                "Python está OFF. Los clientes compatibles retirarán la herramienta automáticamente; si el suyo " +
-                "no lo hace, reinícielo una vez.");
+            TaskDialog.Show(title, spanish
+                ? "Python está OFF. Los clientes compatibles retirarán la herramienta automáticamente; si el suyo no lo hace, reinícielo una vez."
+                : "Python is OFF. Compatible clients remove the tool automatically; if yours does not, restart it once.");
             return Result.Succeeded;
+        }
+
+        internal static bool IsSpanishLanguage(object language)
+        {
+            string value = language == null ? "" : language.ToString();
+            return value.IndexOf("Spanish", StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 

--- a/src/Horizun.Server/McpTasks.cs
+++ b/src/Horizun.Server/McpTasks.cs
@@ -38,7 +38,8 @@ namespace Horizun.Server
 
         public static bool Supports(ToolDef def) =>
             def != null && def.Host == null &&
-            def.Name != "horizun_submit_job" && def.Name != "horizun_execute_python";
+            def.Name != "horizun_submit_job" && def.Name != "horizun_execute_python" &&
+            def.Name != "horizun_request_python_access";
 
         public static JObject Create(
             JObject toolCall, Func<JObject, CancellationToken, JToken> invokeTool, CancellationToken cancellationToken)
@@ -50,8 +51,8 @@ namespace Horizun.Server
             ToolDef def = Tools.Find(tool);
             if (!Supports(def))
                 throw new McpError(-32602,
-                    "'" + tool + "' does not support MCP task augmentation. Host-resident tools, execute_python " +
-                    "and submit_job itself must be called normally.");
+                    "'" + tool + "' does not support MCP task augmentation. Host-resident tools, execute_python, " +
+                    "request_python_access and submit_job itself must be called normally.");
             JToken argumentsToken = toolCall?["arguments"];
             if (argumentsToken != null && argumentsToken.Type != JTokenType.Object &&
                 argumentsToken.Type != JTokenType.Null)

--- a/tests/Horizun.Core.Tests/BridgePostconditionWiringTests.cs
+++ b/tests/Horizun.Core.Tests/BridgePostconditionWiringTests.cs
@@ -77,6 +77,21 @@ namespace Horizun.Core.Tests
         }
 
         [Fact]
+        public void Python_permission_ui_follows_the_revit_language_with_english_fallback()
+        {
+            string ribbon = Source("src/Horizun.Revit/Ribbon.cs");
+            string request = Source("src/Horizun.Revit/Commands/RequestPythonAccessCommand.cs");
+
+            Assert.Contains("ControlledApplication.Language", ribbon);
+            Assert.Contains("data.Application.Application.Language", ribbon);
+            Assert.Contains("app.Application.Language", request);
+            Assert.Contains("Horizun — Python permission", ribbon);
+            Assert.Contains("Enable Python until I disable it", ribbon);
+            Assert.Contains("Activar Python hasta que yo lo desactive", ribbon);
+            Assert.Contains("return value.IndexOf(\"Spanish\"", ribbon);
+        }
+
+        [Fact]
         public void Create_schedule_has_guarded_commit_and_only_then_sets_committed()
         {
             string src = Source("src/Horizun.Revit/Commands/CreateScheduleCommand.cs");

--- a/tests/Horizun.Core.Tests/SettingsPermissionTests.cs
+++ b/tests/Horizun.Core.Tests/SettingsPermissionTests.cs
@@ -98,7 +98,7 @@ namespace Horizun.Core.Tests
         }
 
         [Fact]
-        public void TemporaryPythonUnlockExpiresFailClosed()
+        public void LegacyTemporaryPythonUnlockStillExpiresFailClosedAfterUpgrade()
         {
             WithSettings(@"{""permission_profile"":""safe_write"",""enable_execute_python"":false,""execute_python_ui_grant_until_utc"":""2999-01-01T00:00:00Z""}", () =>
                 Assert.True(Settings.IsToolAllowed(Contract.Find("horizun_execute_python"), out _)));
@@ -109,25 +109,30 @@ namespace Horizun.Core.Tests
         }
 
         [Fact]
-        public void RevitTemporaryGrantDoesNotPermanentlyElevateSafeWriteProfile()
+        public void RevitPersistentGrantStaysOnUntilOwnerRevokesIt()
         {
             WithSettings(@"{""permission_profile"":""safe_write"",""enable_execute_python"":false,""denied_tools"":[]}", () =>
             {
-                Assert.True(Settings.TryGrantExecutePythonTemporarily(
-                    TimeSpan.FromMinutes(60), out DateTimeOffset until, out string grantError), grantError);
-                Assert.True(until > DateTimeOffset.UtcNow);
+                Assert.True(Settings.TryGrantExecutePythonPersistently(out string grantError), grantError);
                 Assert.Equal("safe_write", Settings.PermissionProfile);
                 Assert.True(Settings.IsToolAllowed(Contract.Find("horizun_execute_python"), out string reason), reason);
                 Assert.False(Settings.IsToolAllowed(Contract.Find("horizun_export"), out _));
 
                 JObject persisted = JObject.Parse(File.ReadAllText(HorizunPaths.SettingsPath()));
                 Assert.Equal("safe_write", (string)persisted["permission_profile"]);
-                Assert.NotNull(persisted["execute_python_ui_grant_until_utc"]);
+                Assert.True((bool)persisted["execute_python_ui_granted"]);
+                Assert.False((bool)persisted["enable_execute_python"]);
+                Assert.NotNull(persisted["execute_python_ui_granted_at_utc"]);
+                Assert.Null(persisted["execute_python_ui_grant_until_utc"]);
                 Assert.NotNull(persisted["denied_tools"]);
 
                 Assert.True(Settings.TryRevokeExecutePython(out string revokeError), revokeError);
                 Assert.False(Settings.IsToolAllowed(Contract.Find("horizun_execute_python"), out _));
                 Assert.Equal("safe_write", Settings.PermissionProfile);
+                JObject revoked = JObject.Parse(File.ReadAllText(HorizunPaths.SettingsPath()));
+                Assert.False((bool)revoked["enable_execute_python"]);
+                Assert.Null(revoked["execute_python_ui_granted"]);
+                Assert.Null(revoked["execute_python_ui_granted_at_utc"]);
             });
         }
 
@@ -136,8 +141,7 @@ namespace Horizun.Core.Tests
         {
             WithSettings("{ not json", () =>
             {
-                Assert.False(Settings.TryGrantExecutePythonTemporarily(
-                    TimeSpan.FromMinutes(60), out _, out string error));
+                Assert.False(Settings.TryGrantExecutePythonPersistently(out string error));
                 Assert.Contains("malformed", error);
                 Assert.Equal("{ not json", File.ReadAllText(HorizunPaths.SettingsPath()));
             });
@@ -150,8 +154,7 @@ namespace Horizun.Core.Tests
             {
                 for (int i = 0; i < 6; i++)
                 {
-                    Assert.True(Settings.TryGrantExecutePythonTemporarily(
-                        TimeSpan.FromMinutes(10), out _, out string grantError), grantError);
+                    Assert.True(Settings.TryGrantExecutePythonPersistently(out string grantError), grantError);
                     Assert.True(Settings.TryRevokeExecutePython(out string revokeError), revokeError);
                 }
                 string directory = Path.GetDirectoryName(HorizunPaths.SettingsPath());
@@ -169,8 +172,7 @@ namespace Horizun.Core.Tests
                     Assert.True(mutex.WaitOne(TimeSpan.FromSeconds(2)));
                     var update = System.Threading.Tasks.Task.Run(() =>
                     {
-                        bool ok = Settings.TryGrantExecutePythonTemporarily(
-                            TimeSpan.FromMinutes(10), out _, out string error);
+                        bool ok = Settings.TryGrantExecutePythonPersistently(out string error);
                         return Tuple.Create(ok, error);
                     });
                     Assert.False(update.Wait(250));

--- a/tests/Horizun.Server.Tests/ContractDriftTests.cs
+++ b/tests/Horizun.Server.Tests/ContractDriftTests.cs
@@ -77,6 +77,20 @@ namespace Horizun.Server.Tests
         }
 
         [Fact]
+        public void Python_permission_request_can_only_ask_a_visible_human_for_persistent_consent()
+        {
+            CommandContract request = Contract.Find("horizun_request_python_access");
+            Assert.NotNull(request);
+            Assert.Equal("horizun_request_python_access", request.Command);
+            Assert.Equal(ToolEffect.HostState, request.Effect);
+            Assert.False(request.Destructive);
+            Assert.Equal(500, (int)request.InputSchema["properties"]?["reason"]?["maxLength"]);
+            Assert.Contains("NEVER SELF-GRANT", request.Description);
+            Assert.Contains("indefinite", request.Description);
+            Assert.DoesNotContain("expires_at", request.InputSchema.ToString());
+        }
+
+        [Fact]
         public void Every_model_mutation_advertises_the_shared_idempotency_key()
         {
             foreach (CommandContract c in Contract.All.Where(c =>

--- a/tests/Horizun.Server.Tests/ExecutePythonContractTests.cs
+++ b/tests/Horizun.Server.Tests/ExecutePythonContractTests.cs
@@ -151,7 +151,8 @@ namespace Horizun.Server.Tests
 
             Assert.Contains("EXECUTION FALLBACK", d);
             Assert.Contains("Disabled by default", d);
-            Assert.Contains("explicitly grant", d);
+            Assert.Contains("explicitly approve", d);
+            Assert.Contains("client cannot grant itself permission", d);
             Assert.Contains("instead of answering 'not supported'", d);
             Assert.Contains("second write", d);
             // The four evidence states, in the description a caller actually reads.

--- a/tests/Horizun.Server.Tests/McpPrimitiveTests.cs
+++ b/tests/Horizun.Server.Tests/McpPrimitiveTests.cs
@@ -160,8 +160,8 @@ namespace Horizun.Server.Tests
                     monitor.CheckNow();
                     Assert.Equal(0, notifications);
 
-                    Assert.True(Horizun.Revit.Core.Settings.TryGrantExecutePythonTemporarily(
-                        TimeSpan.FromMinutes(10), out _, out string error), error);
+                    Assert.True(Horizun.Revit.Core.Settings.TryGrantExecutePythonPersistently(
+                        out string error), error);
                     monitor.CheckNow();
                     Assert.Equal(1, notifications);
                     monitor.CheckNow();

--- a/tests/Horizun.Server.Tests/NoUnimplementedTaskSupportTests.cs
+++ b/tests/Horizun.Server.Tests/NoUnimplementedTaskSupportTests.cs
@@ -4,7 +4,7 @@
 //
 // Down-level clients see no execution block. 2025-11-25 clients see optional
 // exactly for Revit-forwarding tools accepted by submit_job, and forbidden for
-// host tools plus the two explicit exclusions.
+// host tools plus the three explicit exclusions.
 // -----------------------------------------------------------------------------
 using System.Linq;
 using Newtonsoft.Json.Linq;

--- a/tests/Horizun.Server.Tests/TaskSupportTests.cs
+++ b/tests/Horizun.Server.Tests/TaskSupportTests.cs
@@ -5,7 +5,7 @@
 //
 // The same rule drives execution.taskSupport, task admission and the compatible
 // horizun_submit_job extension: Revit-forwarding tools are eligible, host tools,
-// execute_python and submit_job itself are not.
+// execute_python, request_python_access and submit_job itself are not.
 // -----------------------------------------------------------------------------
 using System.Linq;
 using Horizun.Contracts;
@@ -49,7 +49,7 @@ namespace Horizun.Server.Tests
         }
 
         /// <summary>
-        /// The two submit_job refuses BY NAME. Offering these as tasks would advertise
+        /// The three submit_job refuses BY NAME. Offering these as tasks would advertise
         /// something the queue rejects, and the caller would only find out at submit time.
         /// </summary>
         [Fact]
@@ -58,11 +58,12 @@ namespace Horizun.Server.Tests
             CommandContract submit = Contract.Find("horizun_submit_job");
             Assert.NotNull(submit);
             // The exclusion is stated in the tool's own description - "except
-            // execute_python or submit_job itself" - and this test's whole premise rests
+            // execute_python, request_python_access or submit_job itself" - and this test's whole premise rests
             // on it, so the wording is asserted rather than assumed. If somebody widens
             // the queue to accept execute_python, this fails and TaskSupport() has to be
             // revisited in the same change.
-            Assert.Contains("except execute_python or submit_job itself", submit.Description);
+            Assert.Contains("except execute_python, request_python_access or submit_job itself", submit.Description);
+            Assert.False(McpTasks.Supports(Tools.Find("horizun_request_python_access")));
         }
 
         /// <summary>

--- a/tests/Horizun.Server.Tests/ToolListDefaultsTests.cs
+++ b/tests/Horizun.Server.Tests/ToolListDefaultsTests.cs
@@ -31,6 +31,19 @@ namespace Horizun.Server.Tests
             {
                 Assert.False(Advertised("horizun_execute_python"));
                 Assert.NotNull(Tools.DisabledReason("horizun_execute_python"));
+                Assert.True(Advertised("horizun_request_python_access"));
+            });
+        }
+
+        [Fact]
+        public void Persistent_ribbon_grant_exposes_only_python_not_the_rest_of_unsafe_code()
+        {
+            WithDataRoot(@"{""permission_profile"":""safe_write"",""enable_execute_python"":false,""execute_python_ui_granted"":true}", () =>
+            {
+                Assert.True(Advertised("horizun_execute_python"));
+                Assert.True(Advertised("horizun_request_python_access"));
+                Assert.False(Advertised("horizun_export"));
+                Assert.False(Advertised("horizun_save_document"));
             });
         }
 


### PR DESCRIPTION
## Summary
- add persistent owner-controlled Python ON/OFF permission
- allow MCP clients to request the visible Revit consent prompt without granting themselves access
- localize the consent flow for English and Spanish Revit
- bump the official product version to 0.9.6

## Provenance
Generated from the private authoritative tree with publish/make-public-package.ps1. The mandatory 32-term sensitive-name scan passed across 361 public files.