### PR TITLE
ci: ignore per-job NuGet caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ build/
 artifacts/
 dist/
 
+# Per-job NuGet cache used by the release workflow inside the checkout.
+# It is build infrastructure state, never source provenance.
+.horizun-nuget-*/
+
 # Python doc-generation tooling and its output — unrelated to the C# MCP source.
 # Kept out of the tree rather than deleted; move them elsewhere if you prefer.
 __pycache__/


### PR DESCRIPTION
Ignore the per-job NuGet cache that the release workflow creates inside the checkout. This prevents MSBuild provenance stamping from treating build-infrastructure state as a source-tree modification. No product code or release asset changes.