### PR TITLE
Release 1.2.1: support ChatGPT Work

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,10 +3,10 @@
   "name": "io.github.HorizunGroup/horizun-revit-mcp",
   "title": "Horizun Revit MCP",
   "description": "Open-source MCP server for Autodesk Revit: typed BIM edits, families, exports and Power BI.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
-    "url": "https://github.com/HorizunGroup/horizun-revit-mcp",
-    "source": "github"
+    "source": "github",
+    "url": "https://github.com/HorizunGroup/horizun-revit-mcp"
   },
   "websiteUrl": "https://horizunhub.com"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,10 @@ records that pending action. `docs/CLIENTS.md` documents the universal installer
 every client-specific last step, and where an MSIX install really keeps
 `claude_desktop_config.json`.
 
+**ChatGPT Work uses OpenAI's Secure MCP Tunnel and does not need either CLI.**
+Run `scripts/chatgpt-tunnel.ps1 -Status`; the helper names each remaining step,
+protects the API key with Windows DPAPI and launches the same installed server.
+
 TOML literal strings (single quotes) take Windows paths as written; JSON needs
 every backslash doubled. **Raise the tool timeout** if your client has one: a
 `model_scan` or a batch open holds Revit's UI thread for minutes, and a
@@ -339,6 +343,10 @@ hace dentro de Claude Desktop; el asistente prepara y valida el `.mcpb` exacto y
 registra esa acción pendiente. `docs/CLIENTS.md` documenta el instalador universal,
 el último paso de cada cliente y dónde guarda realmente
 `claude_desktop_config.json` una instalación MSIX.
+
+**ChatGPT Work usa Secure MCP Tunnel de OpenAI y no necesita ninguno de los dos
+CLI.** Ejecuta `scripts/chatgpt-tunnel.ps1 -Status`; el asistente indica cada
+paso pendiente, protege la clave API con Windows DPAPI y lanza el mismo servidor.
 
 Comillas simples en TOML (cadena literal: las barras van tal cual); en JSON hay
 que doblar cada barra. **Sube el tool timeout** si el cliente tiene uno: un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 What changed, and — where it matters — what was actually measured rather than
 assumed. Dates are the day the work landed.
 
+## v1.2.1 — 2026-09-04
+
+ChatGPT Work is a supported client through OpenAI's Secure MCP Tunnel. The
+installer ships setup, credential, status and diagnostic helpers and names the
+client explicitly. This was verified in the desktop Work interface with a free
+account. Active organisation-specific classification skills were removed, and a
+release gate prevents their terminology from returning in current product files.
+
 ## v1.2.0 — 2026-09-04
 
 The first release since **1.1.6**, and the version stamp has said `1.2.0` since

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <!-- One product, one release number. The server and every Revit payload
          inherit this value and are packaged/deployed as an inseparable pair. -->
-    <Version>1.2.0</Version>
-    <!-- Published tags never move. v1.2.0 adds typed multi-layer wall
-         decomposition and the production Model Doctor campaign. -->
+    <Version>1.2.1</Version>
+    <!-- Published tags never move. v1.2.1 adds the ChatGPT Work route and
+         removes organisation-specific classification material. -->
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ installed `horizun-mcp.exe`:
 | **Codex** | Registers `horizun-revit` beside existing MCP servers. | Restart Codex. |
 | **Claude Code** | Registers `horizun-revit` at user scope. | Restart Claude Code. |
 | **Claude Desktop** | Builds and stages its `.mcpb` Desktop Extension. | Install the extension once inside Claude Desktop. |
+| **ChatGPT Work** | Installs its Secure MCP Tunnel helper. | Create/start the tunnel and add it in ChatGPT Work. |
 
 The installer waits for Claude Code or Codex to close before editing their
 configuration, makes timestamped backups, preserves every other MCP entry, and
@@ -156,8 +157,14 @@ Extension and inspect every supported client from one screen:
 
 ```powershell
 pwsh -File scripts/install-claude-desktop-extension.ps1   # a real .mcpb Desktop Extension
-pwsh -File scripts/diagnose-integrations.ps1              # Codex, Claude Code and Claude Desktop
+pwsh -File scripts/diagnose-integrations.ps1              # Codex, Claude Code, Claude Desktop and ChatGPT Work
 ```
+
+**ChatGPT Work does not need Codex or Claude Code.** It reaches the same installed
+server through OpenAI's Secure MCP Tunnel. Run
+`scripts/chatgpt-tunnel.ps1 -Status` or use **Configurar ChatGPT Work** in the
+Start menu. This was verified in the desktop Work interface with a free account
+on 2026-09-04; account and workspace controls can vary.
 
 TOML literal strings (single quotes) take Windows paths as they are; JSON needs
 every backslash doubled. **Raise your client's tool timeout** if it has one: a

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -2,10 +2,10 @@
 
 Horizun Revit MCP has one runtime: the installed `horizun-mcp.exe` speaks MCP
 over standard input/output and the Revit add-in speaks to it over the local named
-pipe. Codex, Claude Code and Claude Desktop all run that same executable. There is
+pipe. Codex, Claude Code, Claude Desktop and ChatGPT Work all reach that same executable. There is
 no client-specific Revit implementation.
 
-## One installer, three clients
+## One installer, four clients
 
 The Windows Setup attached to each GitHub release is the universal installation
 path. It installs the server and every Revit 2023–2027 add-in present in the
@@ -16,6 +16,7 @@ package, then safely prepares each client found on the machine:
 | **Codex** | Adds `[mcp_servers.horizun-revit]` beside existing servers after Codex closes. | Restart Codex. |
 | **Claude Code** | Adds `mcpServers.horizun-revit` beside existing servers after Claude closes. | Restart Claude Code. |
 | **Claude Desktop** | Stages and validates a `.mcpb` that names the installed server. | Install that extension once inside Claude Desktop. |
+| **ChatGPT Work** | Installs the tunnel helpers for the same server. | Create the OpenAI tunnel, store its API key locally and start it. |
 
 The configuration formats are owned by the clients, so there is no single file
 that all three consume. Setup is the single user-facing flow: it deploys one
@@ -142,6 +143,23 @@ pwsh -File scripts/install-claude-desktop-extension.ps1 -ConfigFallback
 
 The fallback refuses to edit the file while Claude Desktop is running because
 the application can overwrite it from memory when it exits.
+
+## ChatGPT Work
+
+ChatGPT Work connects to the installed stdio server through OpenAI's Secure MCP
+Tunnel and does not require Codex or Claude Code. This route was verified in the
+ChatGPT desktop Work interface with a free account on 2026-09-04. Account and
+workspace controls can vary, so diagnostics report observed tunnel state.
+
+```powershell
+pwsh -File scripts/chatgpt-tunnel.ps1 -Status
+pwsh -File scripts/chatgpt-tunnel.ps1 -SetApiKey
+pwsh -File scripts/chatgpt-tunnel.ps1 -Init -TunnelId tunnel_...
+pwsh -File scripts/chatgpt-tunnel.ps1 -Start -IUnderstandTrafficLeavesThisMachine
+```
+
+The helper uses OpenAI's `tunnel-client`, protects the API key with Windows DPAPI
+for the current user, opens no inbound port and runs the same `horizun-mcp.exe`.
 
 ## Diagnose and repair
 

--- a/docs/RELEASE-1.2.1.md
+++ b/docs/RELEASE-1.2.1.md
@@ -1,0 +1,11 @@
+# Horizun Revit MCP 1.2.1
+
+This patch adds ChatGPT Work through OpenAI's Secure MCP Tunnel. The Windows
+installer provides setup, status, stop and diagnostic entry points while every
+client continues to use the same installed MCP server.
+
+It also removes organisation-specific classification skills and adds a release
+gate that prevents their terminology from returning in current product files.
+
+Install `horizun-mcp-1.2.1-setup.exe`, verify it with `SHA256SUMS.txt`, close
+Revit and run Setup. See [CLIENTS.md](CLIENTS.md) for each client's last step.

--- a/installer/horizun-mcp.iss
+++ b/installer/horizun-mcp.iss
@@ -119,6 +119,12 @@ Name: "{group}\Instalar o reparar la extension de Claude Desktop"; Filename: "{s
 Name: "{group}\Diagnosticar la extension de Claude Desktop"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
   Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File ""{app}\server\client-tools\install-claude-desktop-extension.ps1"" -Diagnose"; \
   WorkingDir: "{app}\server\client-tools"
+Name: "{group}\Configurar ChatGPT Work"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File ""{app}\server\client-tools\chatgpt-tunnel.ps1"" -Status"; \
+  WorkingDir: "{app}\server\client-tools"
+Name: "{group}\Detener conexion con ChatGPT Work"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
+  Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File ""{app}\server\client-tools\chatgpt-tunnel.ps1"" -Stop"; \
+  WorkingDir: "{app}\server\client-tools"
 Name: "{group}\Estado de todos los clientes MCP"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
   Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File ""{app}\server\client-tools\diagnose-integrations.ps1"""; \
   WorkingDir: "{app}\server\client-tools"

--- a/scripts/chatgpt-secret.lib.ps1
+++ b/scripts/chatgpt-secret.lib.ps1
@@ -1,0 +1,204 @@
+#Requires -Version 5.1
+<#
+  The ChatGPT runtime API key: stored by Windows, never by this repository.
+
+  WHERE IT LIVES. Encrypted with DPAPI at CurrentUser scope and written to
+  %LOCALAPPDATA%\Horizun\integrations\chatgpt\control-plane-api-key.dpapi. DPAPI
+  keys the ciphertext to this Windows account: another account on this machine
+  cannot read it, and the file is useless if copied elsewhere. That is the OS
+  secure store, not a home-made one.
+
+  WHERE IT NEVER GOES:
+    - not into the repository, the installer, or any packaged file;
+    - not onto a command line, because /proc-equivalent process listing on Windows
+      shows the full command line of every process to every user session;
+    - not into a log, a diagnostic, or a -Json report. The reports carry
+      api_key_stored: true and nothing else.
+
+  The only place the plaintext exists is the environment block of the
+  tunnel-client child process, which is exactly the interface OpenAI documents
+  (CONTROL_PLANE_API_KEY).
+#>
+
+function Get-HorizunChatGptSecretPath {
+    param([Parameter(Mandatory = $true)][string]$StateRoot)
+    return (Join-Path $StateRoot 'control-plane-api-key.dpapi')
+}
+
+function ConvertFrom-HorizunSecureString {
+    <# SecureString to plaintext, freeing the unmanaged copy in every case. #>
+    param([Parameter(Mandatory = $true)][System.Security.SecureString]$Secure)
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($Secure)
+    try { return [Runtime.InteropServices.Marshal]::PtrToStringUni($bstr) }
+    finally { [Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode($bstr) }
+}
+
+function Set-HorizunChatGptSecret {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$StateRoot,
+        [Parameter(Mandatory = $true)][string]$Secret
+    )
+    if (-not (Test-Path -LiteralPath $StateRoot)) { New-Item -ItemType Directory -Path $StateRoot -Force | Out-Null }
+    Add-Type -AssemblyName System.Security -ErrorAction SilentlyContinue
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Secret)
+    try {
+        $protected = [Security.Cryptography.ProtectedData]::Protect(
+            $bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
+        $path = Get-HorizunChatGptSecretPath -StateRoot $StateRoot
+        [IO.File]::WriteAllBytes($path, $protected)
+    }
+    finally { [Array]::Clear($bytes, 0, $bytes.Length) }
+    return $true
+}
+
+function Test-HorizunChatGptSecret {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$StateRoot)
+    return (Test-Path -LiteralPath (Get-HorizunChatGptSecretPath -StateRoot $StateRoot) -PathType Leaf)
+}
+
+function Get-HorizunChatGptSecret {
+    <#
+      Decrypt. Returns $null when there is nothing stored, and THROWS when there
+      is something stored that this account cannot decrypt - because that is a
+      different situation from "not configured" and silently treating it as one
+      sends the caller off to store a key it already has.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$StateRoot)
+    $path = Get-HorizunChatGptSecretPath -StateRoot $StateRoot
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+    Add-Type -AssemblyName System.Security -ErrorAction SilentlyContinue
+    $protected = [IO.File]::ReadAllBytes($path)
+    try {
+        $bytes = [Security.Cryptography.ProtectedData]::Unprotect(
+            $protected, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
+    }
+    catch {
+        throw ("The stored ChatGPT API key cannot be decrypted by this Windows account. " +
+               "DPAPI ties it to the account that stored it, so a copied profile or a different user " +
+               "produces exactly this. Re-run with -SetApiKey to store it again. ($($_.Exception.Message))")
+    }
+    try { return [Text.Encoding]::UTF8.GetString($bytes) }
+    finally { [Array]::Clear($bytes, 0, $bytes.Length) }
+}
+
+function Remove-HorizunChatGptSecret {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$StateRoot)
+    $path = Get-HorizunChatGptSecretPath -StateRoot $StateRoot
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $false }
+    # Overwrite before unlinking: a deleted file's blocks survive on disk, and
+    # "revoke" has to mean the ciphertext is gone, not merely unlisted.
+    try {
+        $len = (Get-Item -LiteralPath $path).Length
+        if ($len -gt 0) { [IO.File]::WriteAllBytes($path, (New-Object byte[] $len)) }
+    }
+    catch { }
+    Remove-Item -LiteralPath $path -Force
+    return $true
+}
+
+function Test-HorizunTunnelReady {
+    <#
+      Is the tunnel actually CONNECTED, or merely running?
+
+      Those are different, and the difference is invisible from a process list. A
+      tunnel-client that has lost its outbound path keeps running; every ChatGPT
+      tool call then fails while nothing on this machine looks wrong. OpenAI
+      documents `/healthz`, `/readyz`, `/metrics` and a `/ui` on the client's
+      LOOPBACK-ONLY admin surface, so readiness is a question that can be asked.
+
+      This never exposes that surface and never changes its binding - it only
+      reads it, on localhost, if the client published where it is listening.
+
+      Returns .checked=$false when the address is unknown, which is an honest
+      "cannot tell" rather than a guess in either direction.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$StateRoot, [int]$TimeoutSec = 5)
+
+    $result = [ordered]@{ checked = $false; ready = $false; endpoint = $null; detail = $null }
+
+    # The admin address is whatever the client was configured with. Only a value
+    # this integration recorded is used; nothing is scanned for and no port is
+    # guessed, because probing arbitrary local ports is not diagnosis.
+    $addrFile = Join-Path $StateRoot 'admin-endpoint.txt'
+    $endpoint = $null
+    if (Test-Path -LiteralPath $addrFile -PathType Leaf) {
+        $endpoint = (Get-Content -LiteralPath $addrFile -Raw).Trim()
+    }
+    elseif ($env:HORIZUN_TUNNEL_ADMIN_URL) { $endpoint = $env:HORIZUN_TUNNEL_ADMIN_URL.Trim() }
+    if (-not $endpoint) {
+        $result.detail = 'no admin endpoint is recorded for this profile, so readiness cannot be read'
+        return [pscustomobject]$result
+    }
+
+    # Loopback only. An admin surface reachable from elsewhere is not something
+    # this script will interrogate, let alone encourage.
+    try { $uri = [uri]$endpoint } catch { $result.detail = "not a URL: $endpoint"; return [pscustomobject]$result }
+    if ($uri.Host -notin @('localhost', '127.0.0.1', '::1', '[::1]')) {
+        $result.detail = "refusing to probe a non-loopback admin endpoint ($($uri.Host))"
+        return [pscustomobject]$result
+    }
+
+    $result.endpoint = $endpoint.TrimEnd('/') + '/readyz'
+    try {
+        $r = Invoke-WebRequest -Uri $result.endpoint -TimeoutSec $TimeoutSec -UseBasicParsing -ErrorAction Stop
+        $result.checked = $true
+        $result.ready = ($r.StatusCode -ge 200 -and $r.StatusCode -lt 300)
+        $result.detail = "HTTP $($r.StatusCode)"
+    }
+    catch {
+        $result.checked = $true
+        $result.ready = $false
+        $result.detail = $_.Exception.Message
+    }
+    return [pscustomobject]$result
+}
+
+function Invoke-HorizunTunnelClient {
+    <#
+      Run a tunnel-client subcommand with the key in the ENVIRONMENT, capture its
+      output, and return it. The key is never an argument, and the returned output
+      is scrubbed of anything that looks like one before any caller can print it.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$StateRoot,
+        [int]$TimeoutSec = 120
+    )
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $Path
+    # ProcessStartInfo.ArgumentList is unavailable in Windows PowerShell 5.1.
+    # Quote with the Windows command-line escaping rules; secrets never enter it.
+    $psi.Arguments = (($Arguments | ForEach-Object {
+        if ($_ -notmatch '[\s"]') { $_ }
+        else { '"' + ([regex]::Replace($_, '(\\*)"', '$1$1\"') -replace '(\\+)$', '$1$1') + '"' }
+    }) -join ' ')
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.WorkingDirectory = $StateRoot
+    $secret = $null
+    if (Test-HorizunChatGptSecret -StateRoot $StateRoot) {
+        $secret = Get-HorizunChatGptSecret -StateRoot $StateRoot
+        $psi.EnvironmentVariables['CONTROL_PLANE_API_KEY'] = $secret
+    }
+    $p = [Diagnostics.Process]::Start($psi)
+    $out = $p.StandardOutput.ReadToEndAsync()
+    $err = $p.StandardError.ReadToEndAsync()
+    if (-not $p.WaitForExit($TimeoutSec * 1000)) { try { $p.Kill() } catch { } }
+    $text = (($out.Result + "`n" + $err.Result)).Trim()
+    if ($secret) {
+        # A client that echoes its own configuration must not turn a diagnostic
+        # into a place the key is written down.
+        $text = $text.Replace($secret, '<redacted>')
+        $secret = $null
+    }
+    $text = [regex]::Replace($text, 'sk-[A-Za-z0-9_\-]{8,}', '<redacted>')
+    return [pscustomobject]@{ exit_code = $p.ExitCode; output = $text }
+}

--- a/scripts/chatgpt-tunnel.ps1
+++ b/scripts/chatgpt-tunnel.ps1
@@ -1,0 +1,388 @@
+#Requires -Version 5.1
+<#
+  Connect ChatGPT Work to this machine's Horizun bridge through OpenAI's tunnel.
+
+  WHAT THE OFFICIAL MECHANISM ACTUALLY IS - checked against OpenAI's documentation
+  before a line of this was written, because inventing an endpoint would be worse
+  than shipping nothing:
+
+    Secure MCP Tunnel. `tunnel-client` runs INSIDE this network, makes an
+    OUTBOUND HTTPS connection to api.openai.com/v1/tunnel/*, long-polls for
+    queued MCP work, forwards each JSON-RPC request to the private MCP server and
+    posts the reply back through the same tunnel. ChatGPT reaches it by creating a
+    developer-mode app and choosing Tunnel under Connection.
+    -- developers.openai.com/api/docs/guides/secure-mcp-tunnels
+
+  AND THE DECISIVE DETAIL: that client speaks **stdio** to the private server, via
+  `--mcp-command`. So Horizun needs NO adapter, NO HTTP listener and NO second
+  transport. The exact same horizun-mcp.exe that Codex and Claude Desktop launch
+  is the one ChatGPT reaches, unmodified - which is why JSON-RPC framing,
+  initialize, sessions, tools/list with list_changed, tools/call,
+  structuredContent, the error codes, cancellation, the bounded FIFO queue and its
+  backpressure, and long jobs through submit_job/job_status all behave identically.
+  There is nothing to keep in sync because there is no second implementation.
+
+  WHAT THIS SCRIPT DOES NOT DO, and will not be talked into doing:
+    - It does not download tunnel-client. That binary is OpenAI's; the user
+      installs it from the official release page.
+    - It does not create the tunnel, the developer-mode app, or enable anything
+      organisation-wide. Those need permissions only the account owner has.
+    - It does not open a port. The server has no listener at all; the only network
+      connection is tunnel-client's outbound one.
+    - It never writes the API key into this repository, a command line, a log, a
+      diagnostic or an installer file. The key lives in the Windows credential
+      store (DPAPI, current user) and reaches tunnel-client only through the
+      environment block of the child process.
+
+  BEFORE ENABLING IT, understand what it means: MCP requests and replies for this
+  Revit travel through OpenAI-hosted infrastructure. -Start refuses without
+  -IUnderstandTrafficLeavesThisMachine for exactly that reason.
+
+    scripts/chatgpt-tunnel.ps1 -Status
+    scripts/chatgpt-tunnel.ps1 -SetApiKey                 # prompts, never echoes
+    scripts/chatgpt-tunnel.ps1 -Init -TunnelId tunnel_...
+    scripts/chatgpt-tunnel.ps1 -Doctor
+    scripts/chatgpt-tunnel.ps1 -Start -IUnderstandTrafficLeavesThisMachine
+    scripts/chatgpt-tunnel.ps1 -Stop
+    scripts/chatgpt-tunnel.ps1 -Revoke                    # stop, forget the key
+
+  Exit codes: 0 done  1 failed  2 could not run  3 done, one user step remains
+#>
+[CmdletBinding()]
+param(
+    [switch]$Status,
+    [switch]$SetApiKey,
+    [switch]$Init,
+    [switch]$Doctor,
+    [switch]$Start,
+    [switch]$Stop,
+    [switch]$Revoke,
+    [string]$TunnelId,
+    [switch]$IUnderstandTrafficLeavesThisMachine,
+    [string]$ServerPath,
+    [string]$TunnelClientPath,
+    [string]$Json,
+    # Test seams.
+    [string]$StateRoot,
+    [string]$StatusPath
+)
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'mcp-clients.lib.ps1')
+. (Join-Path $PSScriptRoot 'mcp-stdio.lib.ps1')
+. (Join-Path $PSScriptRoot 'integration-status.lib.ps1')
+. (Join-Path $PSScriptRoot 'chatgpt-secret.lib.ps1')
+
+$CLIENT = 'chatgpt'
+$PROFILE_NAME = 'horizun-revit'
+$RELEASES = 'https://github.com/openai/tunnel-client/releases/latest'
+$TUNNEL_SETTINGS = 'https://platform.openai.com/settings/organization/tunnels'
+$CHATGPT_APPS = 'https://chatgpt.com/plugins'
+
+if (-not $StateRoot) { $StateRoot = Join-Path $env:LOCALAPPDATA 'Horizun\integrations\chatgpt' }
+if (-not $ServerPath) { $ServerPath = Join-Path $env:LOCALAPPDATA 'Programs\Horizun\MCP\server\horizun-mcp.exe' }
+$pidFile = Join-Path $StateRoot 'tunnel-client.pid'
+$profileFile = Join-Path $StateRoot 'profiles\horizun-revit.yaml'
+
+$actions = New-Object System.Collections.Generic.List[object]
+$problems = New-Object System.Collections.Generic.List[string]
+function Say($m, $c = 'Gray') { Write-Host "  $m" -ForegroundColor $c }
+function Act($what, $ok, $detail) {
+    $actions.Add([pscustomobject]@{ action = $what; ok = [bool]$ok; detail = $detail }) | Out-Null
+    if ($ok) { Say $what 'Green' } else { Say "$what - $detail" 'Red'; $problems.Add("$what : $detail") | Out-Null }
+}
+function Ensure-StateRoot {
+    if (-not (Test-Path -LiteralPath $StateRoot)) { New-Item -ItemType Directory -Path $StateRoot -Force | Out-Null }
+}
+
+Write-Host ""
+Write-Host "Horizun in ChatGPT - OpenAI Secure MCP Tunnel" -ForegroundColor Cyan
+
+$tunnel = Get-HorizunTunnelClient -Override $TunnelClientPath
+$chatgpt = Get-HorizunChatGptDesktop
+$keyPresent = Test-HorizunChatGptSecret -StateRoot $StateRoot
+
+# --- the running client ---------------------------------------------------------
+function Get-RunningTunnel {
+    if (-not (Test-Path -LiteralPath $pidFile -PathType Leaf)) { return $null }
+    $raw = (Get-Content -LiteralPath $pidFile -Raw).Trim()
+    if ($raw -notmatch '^\d+$') { return $null }
+    $p = Get-Process -Id ([int]$raw) -ErrorAction SilentlyContinue
+    if (-not $p) { return $null }
+    # A recycled process id must not be reported as our tunnel.
+    if ($p.ProcessName -notmatch '(?i)tunnel-client') { return $null }
+    return $p
+}
+$running = Get-RunningTunnel
+
+# --- set the key ----------------------------------------------------------------
+if ($SetApiKey) {
+    Ensure-StateRoot
+    Write-Host ""
+    Say "The runtime API key for tunnel-client, from $TUNNEL_SETTINGS." 'Cyan'
+    Say "It is read without echo, stored with DPAPI for this Windows user only, and" 'Cyan'
+    Say "handed to tunnel-client through its environment - never a command line." 'Cyan'
+    $secure = Read-Host -Prompt '  CONTROL_PLANE_API_KEY' -AsSecureString
+    $plain = ConvertFrom-HorizunSecureString $secure
+    if ([string]::IsNullOrWhiteSpace($plain)) { Act 'store the API key' $false 'nothing was entered'; exit 1 }
+    if ($plain -notmatch '^sk-') {
+        # Named, not blocked: the documented shape is sk-..., and a pasted tunnel
+        # id or a truncated key otherwise fails much later with a network error.
+        Say "WARNING: that does not look like an sk-... runtime key." 'Yellow'
+    }
+    Set-HorizunChatGptSecret -StateRoot $StateRoot -Secret $plain
+    $plain = $null
+    Act 'stored the API key in the Windows credential store (DPAPI, current user)' $true $null
+    $keyPresent = $true
+}
+
+# --- stop / revoke ---------------------------------------------------------------
+if ($Stop -or $Revoke) {
+    if ($running) {
+        try {
+            $running.CloseMainWindow() | Out-Null
+            if (-not $running.WaitForExit(5000)) { $running.Kill(); $running.WaitForExit(10000) }
+            Act ("stopped tunnel-client (pid {0}); the outbound connection is gone" -f $running.Id) $true $null
+        }
+        catch { Act 'stop tunnel-client' $false $_.Exception.Message }
+    }
+    else { Act 'tunnel-client was not running' $true $null }
+    Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+    $running = $null
+
+    if ($Revoke) {
+        if (Remove-HorizunChatGptSecret -StateRoot $StateRoot) { Act 'forgot the stored API key' $true $null }
+        else { Act 'there was no stored API key to forget' $true $null }
+        if (Test-Path -LiteralPath $profileFile) {
+            Remove-Item -LiteralPath $profileFile -Force
+            Act 'removed the tunnel-client profile' $true $null
+        }
+        Say ""
+        Say "REVOKING THE TUNNEL ITSELF is a separate act, and only you can do it:" 'Cyan'
+        Say "delete the tunnel at $TUNNEL_SETTINGS, and remove the app in ChatGPT." 'Cyan'
+        Set-HorizunIntegrationState -Client $CLIENT -State 'pending_user_action' -StatusPath $StatusPath `
+            -Detail 'Everything on this machine is stopped and forgotten: no process, no stored key, no profile.' `
+            -PendingUserAction ("Delete the tunnel at $TUNNEL_SETTINGS and remove the developer-mode app at $CHATGPT_APPS. " +
+                                'Stopping the client here ends the connection; only you can delete the OpenAI-side objects.') | Out-Null
+    }
+    else {
+        Set-HorizunIntegrationState -Client $CLIENT -State 'configured' -StatusPath $StatusPath `
+            -Detail 'tunnel-client is stopped. Nothing on this machine is reachable from OpenAI until it is started again.' | Out-Null
+    }
+    if ($problems.Count -gt 0) { exit 1 }
+    exit 0
+}
+
+# --- what is in place ------------------------------------------------------------
+if ($tunnel.installed) {
+    Act ("tunnel-client found: {0}" -f $tunnel.path) $true $null
+    Say ("  version   " + $(if ($tunnel.version) { $tunnel.version } else { '<it reported none>' }))
+    Say ("  source    {0}" -f $tunnel.source)
+    Say ("  sha256    {0}" -f $tunnel.sha256)
+    Say ("  signature {0}{1}" -f $tunnel.signature_status,
+         $(if ($tunnel.signer) { " ($($tunnel.signer))" } else { '' }))
+    # THE FLAG THIS WHOLE INTEGRATION RESTS ON. Horizun's server is stdio; a
+    # build with no --mcp-command has nothing to connect to, and finding that
+    # out from a failed `run` is finding it out in the worst place.
+    if ($tunnel.supports_mcp_command -eq $false) {
+        Act 'this tunnel-client supports --mcp-command' $false `
+            ("the installed build does not advertise --mcp-command, which is how a stdio server is reached. " +
+             "It is too old for this integration; get the current release from $RELEASES.")
+    }
+    elseif ($null -eq $tunnel.supports_mcp_command) {
+        Say "could not read this build's help output, so --mcp-command support is UNKNOWN; -Doctor will settle it." 'Yellow'
+    }
+    else { Act 'this tunnel-client supports --mcp-command (stdio)' $true $null }
+}
+else {
+    Say "tunnel-client is NOT installed." 'Yellow'
+    Say "It is OpenAI's binary, not Horizun's; this script never downloads it."
+    Say "Get it from $RELEASES and put it on PATH."
+}
+Say ("ChatGPT Work desktop app: " + $(if ($chatgpt.installed) { "installed, $($chatgpt.version)" } else { 'not installed' }))
+Say ("runtime API key:     " + $(if ($keyPresent) { 'stored (DPAPI, this user)' } else { 'not stored' }))
+Say ("tunnel-client:       " + $(if ($running) { "RUNNING, pid $($running.Id)" } else { 'not running' }))
+if ($running) {
+    # A process that is alive is not a connection that is up. tunnel-client
+    # publishes /readyz on its loopback admin surface; when it has lost the
+    # outbound path it keeps running and every ChatGPT tool call fails with
+    # nothing on this machine looking wrong.
+    $health = Test-HorizunTunnelReady -StateRoot $StateRoot
+    if ($health.checked) {
+        if ($health.ready) { Act ("the tunnel is connected and ready ({0})" -f $health.endpoint) $true $null }
+        else {
+            Act 'the tunnel is connected' $false `
+                ("tunnel-client is running but its readiness endpoint says it is NOT ready ({0}). " -f $health.detail) +
+                'Requests through the tunnel fail until it reconnects; run -Doctor, then -Stop and -Start.'
+        }
+    }
+    else { Say "  (its admin endpoint was not reachable, so connectivity is unknown - run -Doctor)" 'DarkGray' }
+}
+
+# --- the server it will expose ----------------------------------------------------
+$probe = $null
+if (Test-Path -LiteralPath $ServerPath -PathType Leaf) {
+    $probe = Invoke-HorizunMcpProbe -Command $ServerPath -ListTools -TimeoutSec 120
+    if ($probe.ok) {
+        Act ("the server tunnel-client would launch answers MCP: {0} tools, list_changed={1}" -f $probe.tool_count, $probe.list_changed) $true $null
+    }
+    else { Act 'the server answers MCP' $false $probe.problem }
+}
+else { Act 'find the installed server' $false "$ServerPath does not exist - install Horizun Revit MCP first" }
+
+# --- init -------------------------------------------------------------------------
+if ($Init) {
+    Write-Host ""
+    Write-Host "Creating the tunnel-client profile" -ForegroundColor Cyan
+    if (-not $tunnel.installed) { Act 'run tunnel-client init' $false 'tunnel-client is not installed'; exit 2 }
+    if (-not $TunnelId) { Act 'run tunnel-client init' $false "-TunnelId is required; create the tunnel at $TUNNEL_SETTINGS and pass its id"; exit 2 }
+    if ($TunnelId -notmatch '^tunnel_[0-9a-f]{32}$') {
+        Act 'run tunnel-client init' $false "'$TunnelId' is not the documented tunnel id shape (tunnel_ followed by 32 hex characters)"
+        exit 2
+    }
+    if (-not $keyPresent) { Act 'run tunnel-client init' $false 'no API key is stored; run this script with -SetApiKey first'; exit 2 }
+    Ensure-StateRoot
+
+    # The profile is written by tunnel-client's own `init`, from its own sample.
+    # Hand-writing that YAML would be guessing at a format this product does not
+    # own, and a guess that parses today breaks on the client's next release.
+    $args = @('init',
+              '--sample', 'sample_mcp_stdio_local',
+              '--profile', $PROFILE_NAME,
+              '--tunnel-id', $TunnelId,
+              '--mcp-command', $ServerPath)
+    $r = Invoke-HorizunTunnelClient -Path $tunnel.path -Arguments $args -StateRoot $StateRoot
+    if ($r.exit_code -eq 0) { Act "tunnel-client init wrote the '$PROFILE_NAME' profile for $ServerPath" $true $null }
+    else { Act 'tunnel-client init' $false ("exit {0}: {1}" -f $r.exit_code, $r.output) }
+}
+
+# --- doctor -------------------------------------------------------------------------
+if ($Doctor) {
+    Write-Host ""
+    Write-Host "tunnel-client doctor" -ForegroundColor Cyan
+    if (-not $tunnel.installed) { Act 'run tunnel-client doctor' $false 'tunnel-client is not installed'; exit 2 }
+    $r = Invoke-HorizunTunnelClient -Path $tunnel.path -Arguments @('doctor', '--profile', $PROFILE_NAME, '--explain') -StateRoot $StateRoot
+    Write-Host $r.output
+    if ($r.exit_code -eq 0) { Act 'tunnel-client doctor reported the profile healthy' $true $null }
+    else { Act 'tunnel-client doctor' $false ("exit {0}" -f $r.exit_code) }
+}
+
+# --- start -------------------------------------------------------------------------
+if ($Start) {
+    Write-Host ""
+    if (-not $IUnderstandTrafficLeavesThisMachine) {
+        Write-Host "  REFUSED, and here is the decision this needs from you." -ForegroundColor Yellow
+        Say "Starting the tunnel makes this Revit reachable from ChatGPT. Every MCP request" 'Yellow'
+        Say "and reply travels through OpenAI-hosted infrastructure - the model names, the" 'Yellow'
+        Say "element data, the audit findings, everything a tool returns. The server stays" 'Yellow'
+        Say "private and no port is opened; the traffic still leaves this machine." 'Yellow'
+        Say "Re-run with -IUnderstandTrafficLeavesThisMachine if that is what you want." 'Yellow'
+        Set-HorizunIntegrationState -Client $CLIENT -State 'pending_user_action' -StatusPath $StatusPath `
+            -Detail 'Everything is prepared. The tunnel was not started: enabling it sends MCP traffic through OpenAI-hosted infrastructure and that is a decision for the owner of the machine.' `
+            -PendingUserAction 'Re-run with -Start -IUnderstandTrafficLeavesThisMachine to accept that MCP traffic for this Revit passes through OpenAI services.' | Out-Null
+        exit 3
+    }
+    if (-not $tunnel.installed) { Act 'start tunnel-client' $false 'tunnel-client is not installed'; exit 2 }
+    if (-not $keyPresent) { Act 'start tunnel-client' $false 'no API key is stored; run with -SetApiKey first'; exit 2 }
+    if ($running) { Act ("tunnel-client is already running (pid {0})" -f $running.Id) $true $null }
+    else {
+        Ensure-StateRoot
+        $secret = Get-HorizunChatGptSecret -StateRoot $StateRoot
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $tunnel.path
+        foreach ($a in @('run', '--profile', $PROFILE_NAME)) { $null = $psi.ArgumentList.Add($a) }
+        $psi.UseShellExecute = $false
+        $psi.WorkingDirectory = $StateRoot
+        # THE KEY GOES HERE AND NOWHERE ELSE. Not in ArgumentList, which every
+        # process on this machine can read off our command line.
+        $psi.Environment['CONTROL_PLANE_API_KEY'] = $secret
+        $secret = $null
+        $p = [Diagnostics.Process]::Start($psi)
+        Set-Content -LiteralPath $pidFile -Value ([string]$p.Id) -Encoding ASCII
+        Start-Sleep -Milliseconds 1500
+        if ($p.HasExited) { Act 'start tunnel-client' $false ("it exited immediately with code {0}; run -Doctor" -f $p.ExitCode) }
+        else {
+            $running = $p
+            Act ("started tunnel-client, pid {0}" -f $p.Id) $true $null
+        }
+    }
+}
+
+# --- state ---------------------------------------------------------------------------
+Write-Host ""
+$state = $null; $detail = $null; $pending = $null
+$evidence = [ordered]@{
+    transport             = 'OpenAI Secure MCP Tunnel, stdio to the local server (tunnel-client --mcp-command)'
+    adapter_written       = $false
+    local_listener_opened = $false
+    tunnel_client_path    = $tunnel.path
+    tunnel_client_version = $tunnel.version
+    chatgpt_desktop       = $chatgpt.installed
+    chatgpt_desktop_version = $chatgpt.version
+    api_key_stored        = $keyPresent
+    api_key_location      = 'DPAPI-protected file under %LOCALAPPDATA%\Horizun\integrations\chatgpt, current user only'
+    profile               = $PROFILE_NAME
+    server_path           = $ServerPath
+    server_answers_mcp    = $(if ($probe) { [bool]$probe.ok } else { $false })
+    server_tool_count     = $(if ($probe) { $probe.tool_count } else { 0 })
+    tools_list_changed    = $(if ($probe) { $probe.list_changed } else { $null })
+    tunnel_running        = [bool]$running
+    tunnel_ready          = $(if ($running) { (Test-HorizunTunnelReady -StateRoot $StateRoot).ready } else { $false })
+    supports_mcp_command  = $tunnel.supports_mcp_command
+    tunnel_client_sha256  = $tunnel.sha256
+    tunnel_client_signature = $tunnel.signature_status
+    execute_python_granted_by_this = $false
+}
+
+if ($problems.Count -gt 0) {
+    $state = 'failed'
+    $detail = 'The ChatGPT connection did not come up: ' + ($problems -join ' | ')
+}
+elseif ($running) {
+    $state = 'configured'
+    $detail = "tunnel-client is running against the '$PROFILE_NAME' profile. The tools appear in ChatGPT once the developer-mode app is pointed at the tunnel."
+}
+elseif (-not $tunnel.installed) {
+    $state = 'pending_user_action'
+    $detail = 'The local half is ready: the server answers MCP over stdio, which is exactly what tunnel-client forwards. OpenAI''s tunnel-client is not installed.'
+    $pending = "Install tunnel-client from $RELEASES, create a tunnel at $TUNNEL_SETTINGS, then run: scripts/chatgpt-tunnel.ps1 -SetApiKey; -Init -TunnelId tunnel_...; -Start -IUnderstandTrafficLeavesThisMachine"
+}
+elseif (-not $keyPresent) {
+    $state = 'pending_user_action'
+    $detail = 'tunnel-client is installed and the server answers MCP. No runtime API key is stored.'
+    $pending = "Create a runtime API key at $TUNNEL_SETTINGS and run: scripts/chatgpt-tunnel.ps1 -SetApiKey"
+}
+else {
+    $state = 'pending_user_action'
+    $detail = 'tunnel-client and the key are in place, and the server answers MCP. The tunnel is not running.'
+    $pending = "Run: scripts/chatgpt-tunnel.ps1 -Start -IUnderstandTrafficLeavesThisMachine - then create the developer-mode app at $CHATGPT_APPS and choose Tunnel under Connection."
+}
+
+Set-HorizunIntegrationState -Client $CLIENT -State $state -Detail $detail -PendingUserAction $pending `
+    -Evidence ([pscustomobject]$evidence) -StatusPath $StatusPath | Out-Null
+
+Write-Host ("  state: {0}" -f $state) -ForegroundColor $(if ($state -eq 'configured') { 'Green' } elseif ($state -eq 'failed') { 'Red' } else { 'Yellow' })
+Say $detail
+if ($pending) { Write-Host ""; Say "ONE STEP REMAINS, and it is yours:" 'Cyan'; Say $pending 'Cyan' }
+Write-Host ""
+Say "Whatever happens here, horizun_execute_python stays refused until the owner of this" 'DarkGray'
+Say "machine grants it from inside Revit. Connecting ChatGPT does not grant it." 'DarkGray'
+
+if ($Json) {
+    $dir = Split-Path -Parent $Json
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    [pscustomobject]@{
+        generated_utc       = (Get-Date).ToUniversalTime().ToString('o')
+        client              = $CLIENT
+        state               = $state
+        detail              = $detail
+        pending_user_action = $pending
+        evidence            = [pscustomobject]$evidence
+        actions             = $actions
+        problems            = $problems
+    } | ConvertTo-Json -Depth 10 | Out-File -FilePath $Json -Encoding utf8
+    Say "wrote $Json"
+}
+
+if ($problems.Count -gt 0) { exit 1 }
+if ($state -eq 'pending_user_action') { exit 3 }
+exit 0

--- a/scripts/chatgpt-tunnel.tests.ps1
+++ b/scripts/chatgpt-tunnel.tests.ps1
@@ -1,0 +1,234 @@
+#Requires -Version 5.1
+<#
+  The ChatGPT side: the credential, the diagnosis, and what each refusal says.
+
+  The credential store is exercised for the four states that actually happen on a
+  real machine - stored, revoked, CORRUPTED, and belonging to another Windows
+  account - because the third and fourth are the ones a naive implementation gets
+  wrong by reporting "not configured" and sending the user off to store a key it
+  already has.
+
+  Nothing here needs tunnel-client, a tunnel, an API key, ChatGPT, or a network.
+  What those WOULD prove is exactly what this file refuses to claim.
+#>
+$ErrorActionPreference = 'Stop'
+
+$failed = 0
+function Assert($name, $condition, $detail) {
+    if ($condition) { Write-Host "  PASS  $name" -ForegroundColor Green }
+    else {
+        Write-Host "  FAIL  $name" -ForegroundColor Red
+        if ($detail) { Write-Host "        $detail" }
+        $script:failed++
+    }
+}
+
+. (Join-Path $PSScriptRoot 'chatgpt-secret.lib.ps1')
+. (Join-Path $PSScriptRoot 'mcp-clients.lib.ps1')
+
+$root = Join-Path ([IO.Path]::GetTempPath()) ('hz-chatgpt-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $root | Out-Null
+$tunnelScript = Join-Path $PSScriptRoot 'chatgpt-tunnel.ps1'
+
+try {
+    # ======================================================================
+    Write-Host ""
+    Write-Host "The credential: four states, not two" -ForegroundColor Cyan
+
+    $store = Join-Path $root 'store'
+    $secret = 'sk-' + [guid]::NewGuid().ToString('N') + [guid]::NewGuid().ToString('N')
+
+    Assert 'absent reads as absent' (-not (Test-HorizunChatGptSecret -StateRoot $store)) $null
+    Assert 'and reading an absent credential returns null rather than throwing' `
+        ($null -eq (Get-HorizunChatGptSecret -StateRoot $store)) $null
+
+    Set-HorizunChatGptSecret -StateRoot $store -Secret $secret | Out-Null
+    $file = Get-HorizunChatGptSecretPath -StateRoot $store
+    Assert 'stored reads as stored' (Test-HorizunChatGptSecret -StateRoot $store) $null
+    Assert 'it round-trips byte for byte' ((Get-HorizunChatGptSecret -StateRoot $store) -ceq $secret) $null
+
+    $raw = [IO.File]::ReadAllBytes($file)
+    $asText = [Text.Encoding]::UTF8.GetString($raw)
+    $asAscii = [Text.Encoding]::ASCII.GetString($raw)
+    Assert 'the ciphertext contains the key in NO encoding a grep would find' `
+        (-not $asText.Contains($secret) -and -not $asAscii.Contains($secret)) $null
+    Assert 'DPAPI actually expanded it - a plaintext file would be the same length' `
+        ($raw.Length -gt $secret.Length) "$($raw.Length) bytes for a $($secret.Length)-character key"
+
+    # ---- CORRUPTION. The distinction that matters: unreadable is not absent.
+    $corrupt = Join-Path $root 'corrupt'
+    New-Item -ItemType Directory -Path $corrupt -Force | Out-Null
+    $corruptFile = Get-HorizunChatGptSecretPath -StateRoot $corrupt
+    [IO.File]::WriteAllBytes($corruptFile, [byte[]](1..64))
+    Assert 'a corrupted credential still reads as PRESENT' `
+        (Test-HorizunChatGptSecret -StateRoot $corrupt) 'it reported absent, and the user would be told to store a key they already have'
+    $threw = $false; $message = $null
+    try { Get-HorizunChatGptSecret -StateRoot $corrupt | Out-Null } catch { $threw = $true; $message = $_.Exception.Message }
+    Assert 'decrypting it THROWS rather than silently returning nothing' $threw $null
+    Assert 'and the message says what actually happened and how to fix it' `
+        ($message -match '(?i)cannot be decrypted' -and $message -match '(?i)-SetApiKey') $message
+
+    # ---- Per-user isolation.
+    #
+    # WHAT ACTUALLY CARRIES IT is the scope the blob was PROTECTED with:
+    # CurrentUser binds the ciphertext to this account's master key, so no other
+    # Windows account can decrypt it. LocalMachine binds it to the machine, so
+    # every account can - which is why using it here would be the defect.
+    #
+    # Measured first, and it disproved this test's original premise: Unprotect
+    # reads the scope from the blob itself and will happily decrypt a
+    # LocalMachine blob whatever scope the caller passes. So "pass the wrong
+    # scope and watch it fail" proves nothing. What can be proved without a
+    # second Windows account is that the scope parameter is real and that this
+    # library uses the isolating one.
+    Add-Type -AssemblyName System.Security -ErrorAction SilentlyContinue
+    $plain = [Text.Encoding]::UTF8.GetBytes($secret)
+    $userBlob = [Security.Cryptography.ProtectedData]::Protect($plain, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
+    $machineBlob = [Security.Cryptography.ProtectedData]::Protect($plain, $null, [Security.Cryptography.DataProtectionScope]::LocalMachine)
+    Assert 'the two DPAPI scopes really do produce different ciphertext for the same key' `
+        ([Convert]::ToBase64String($userBlob) -ne [Convert]::ToBase64String($machineBlob)) $null
+
+    $libSource = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'chatgpt-secret.lib.ps1') -Raw
+    $scopesUsed = @($libSource -split 'DataProtectionScope\]::' | Select-Object -Skip 1 |
+                    ForEach-Object { ($_ -split '[^A-Za-z]')[0] } | Sort-Object -Unique)
+    Assert 'the credential library uses CurrentUser and ONLY CurrentUser' `
+        (($scopesUsed -join ',') -eq 'CurrentUser') `
+        ("scopes found: " + ($scopesUsed -join ', ') + " - a LocalMachine scope would let every account on this machine read the key")
+
+    # ---- Revocation removes the ciphertext, it does not merely unlist it.
+    $before = (Get-Item -LiteralPath $file).Length
+    Assert 'revoking reports that something was removed' (Remove-HorizunChatGptSecret -StateRoot $store) $null
+    Assert 'and the file is gone' (-not (Test-Path -LiteralPath $file)) $null
+    Assert 'revoking again is a no-op rather than an error' `
+        (-not (Remove-HorizunChatGptSecret -StateRoot $store)) $null
+    Assert 'the store reads as absent again' (-not (Test-HorizunChatGptSecret -StateRoot $store)) "was $before bytes"
+
+    # ======================================================================
+    Write-Host ""
+    Write-Host "Nothing prints the key" -ForegroundColor Cyan
+
+    $scrubRoot = Join-Path $root 'scrub'
+    New-Item -ItemType Directory -Path $scrubRoot -Force | Out-Null
+    Set-HorizunChatGptSecret -StateRoot $scrubRoot -Secret $secret | Out-Null
+    # A stand-in for a client that echoes its own configuration back at you.
+    $echo = Join-Path $env:SystemRoot 'System32\cmd.exe'
+    $r = Invoke-HorizunTunnelClient -Path $echo -Arguments @('/c', 'echo %CONTROL_PLANE_API_KEY%') -StateRoot $scrubRoot
+    Assert 'a client that echoes the key has it scrubbed before any caller sees it' `
+        (-not $r.output.Contains($secret)) $r.output
+    Assert 'and what is left says it was redacted rather than looking like a blank' `
+        ($r.output -match 'redacted') $r.output
+    Remove-HorizunChatGptSecret -StateRoot $scrubRoot | Out-Null
+
+    # ======================================================================
+    Write-Host ""
+    Write-Host "Diagnosis when tunnel-client is missing" -ForegroundColor Cyan
+
+    $t = Get-HorizunTunnelClient -Override (Join-Path $root 'no-such-tunnel-client.exe')
+    Assert 'a missing tunnel-client reports installed=false without throwing' ($t.installed -eq $false) $null
+    Assert 'and it names the official place to get it' `
+        ($t.download_from -eq 'https://github.com/openai/tunnel-client/releases/latest') $t.download_from
+
+    $status = Join-Path $root 'status.json'
+    $out = & pwsh -NoProfile -File $tunnelScript -Status -StateRoot (Join-Path $root 'cg') -StatusPath $status 2>&1 | Out-String
+    Assert 'the wizard says tunnel-client is not installed and that Horizun never downloads it' `
+        ($out -match 'tunnel-client is NOT installed' -and $out -match "never downloads it") $out
+    $st = (Get-Content -LiteralPath $status -Raw | ConvertFrom-Json).integrations.chatgpt
+    Assert 'the recorded state is pending_user_action, not failed - nothing is broken' `
+        ($st.state -eq 'pending_user_action') $st.state
+    Assert 'and the pending action names the download, the tunnel and the commands, in order' `
+        ($st.pending_user_action -match 'releases/latest' -and
+         $st.pending_user_action -match 'settings/organization/tunnels' -and
+         $st.pending_user_action -match '-SetApiKey' -and
+         $st.pending_user_action -match '-Init' -and
+         $st.pending_user_action -match '-Start') $st.pending_user_action
+
+    # ======================================================================
+    Write-Host ""
+    Write-Host "What it refuses, and how it says so" -ForegroundColor Cyan
+
+    $out = & pwsh -NoProfile -File $tunnelScript -Start -StateRoot (Join-Path $root 'cg2') `
+        -StatusPath (Join-Path $root 'status2.json') 2>&1 | Out-String
+    Assert 'starting without the traffic acknowledgement is REFUSED' ($out -match 'REFUSED') $out
+    Assert 'and the refusal explains what leaving this machine means, concretely' `
+        ($out -match 'OpenAI-hosted infrastructure' -and $out -match 'element data') $out
+
+    foreach ($bad in @('not-a-tunnel-id', 'tunnel_short', 'tunnel_ZZZZ0123456789abcdef0123456789ab')) {
+        $out = & pwsh -NoProfile -File $tunnelScript -Init -TunnelId $bad -TunnelClientPath $env:ComSpec `
+            -StateRoot (Join-Path $root "cg-$([guid]::NewGuid().ToString('N'))") `
+            -StatusPath (Join-Path $root 'status3.json') 2>&1 | Out-String
+        Assert "a malformed tunnel id '$bad' is refused before anything is written" `
+            ($out -match 'not the documented tunnel id shape') $out
+    }
+
+    $out = & pwsh -NoProfile -File $tunnelScript -Init -TunnelId ('tunnel_' + ('a' * 32)) -TunnelClientPath $env:ComSpec `
+        -StateRoot (Join-Path $root 'cg4') -StatusPath (Join-Path $root 'status4.json') 2>&1 | Out-String
+    Assert 'a well-formed id with NO stored key is refused, naming -SetApiKey' `
+        ($out -match 'no API key is stored' -and $out -match '-SetApiKey') $out
+
+    # ======================================================================
+    Write-Host ""
+    Write-Host "Outdated, and connected-but-not-really" -ForegroundColor Cyan
+
+    # A build with no --mcp-command cannot reach a stdio server at all. cmd.exe
+    # stands in for one: it is an executable whose help mentions no such flag.
+    $old = Get-HorizunTunnelClient -Override $env:ComSpec
+    Assert 'a build whose help does not mention --mcp-command is detected as unusable' `
+        ($old.installed -and $old.supports_mcp_command -eq $false) `
+        "installed=$($old.installed) supports=$($old.supports_mcp_command)"
+    Assert 'and its provenance is reported: sha256, signature and source' `
+        ($old.sha256 -and $old.signature_status -and $old.source) `
+        "sha=$($old.sha256) sig=$($old.signature_status) source=$($old.source)"
+
+    $outdatedRoot = Join-Path $root 'outdated'
+    $out = & pwsh -NoProfile -File $tunnelScript -Status -TunnelClientPath $env:ComSpec `
+        -StateRoot $outdatedRoot -StatusPath (Join-Path $root 'status-old.json') 2>&1 | Out-String
+    Assert 'the wizard says the build is too old and points at the current release' `
+        ($out -match 'does not advertise --mcp-command' -and $out -match 'releases/latest') $out
+
+    # Running is not the same as connected.
+    $readyRoot = Join-Path $root 'ready'
+    New-Item -ItemType Directory -Path $readyRoot -Force | Out-Null
+    $r = Test-HorizunTunnelReady -StateRoot $readyRoot
+    Assert 'with no admin endpoint recorded, readiness is UNKNOWN rather than assumed' `
+        ((-not $r.checked) -and (-not $r.ready)) "checked=$($r.checked) ready=$($r.ready)"
+
+    Set-Content -LiteralPath (Join-Path $readyRoot 'admin-endpoint.txt') -Value 'http://10.0.0.5:8080' -Encoding ASCII
+    $r = Test-HorizunTunnelReady -StateRoot $readyRoot
+    Assert 'a NON-loopback admin endpoint is refused rather than probed' `
+        ((-not $r.checked) -and $r.detail -match 'non-loopback') $r.detail
+
+    # A loopback port with nothing on it: reachable question, negative answer.
+    Set-Content -LiteralPath (Join-Path $readyRoot 'admin-endpoint.txt') -Value 'http://127.0.0.1:1' -Encoding ASCII
+    $r = Test-HorizunTunnelReady -StateRoot $readyRoot -TimeoutSec 3
+    Assert 'a loopback endpoint that answers nothing reports checked but NOT ready' `
+        ($r.checked -and (-not $r.ready)) "checked=$($r.checked) ready=$($r.ready) detail=$($r.detail)"
+
+    # ======================================================================
+    Write-Host ""
+    Write-Host "Stopping when nothing is running" -ForegroundColor Cyan
+
+    $stopRoot = Join-Path $root 'cg5'
+    New-Item -ItemType Directory -Path $stopRoot -Force | Out-Null
+    # A stale pid file pointing at a process that is not tunnel-client must not
+    # be treated as our tunnel: pids are recycled, and killing a stranger's
+    # process because a file says so is the worst possible failure here.
+    Set-Content -LiteralPath (Join-Path $stopRoot 'tunnel-client.pid') -Value ([string]$PID) -Encoding ASCII
+    $out = & pwsh -NoProfile -File $tunnelScript -Stop -StateRoot $stopRoot `
+        -StatusPath (Join-Path $root 'status5.json') 2>&1 | Out-String
+    Assert 'a stale pid belonging to another process is NOT treated as the tunnel' `
+        ($out -match 'was not running') $out
+    Assert 'this test process is still alive' (Get-Process -Id $PID -ErrorAction SilentlyContinue) 'it killed the test host'
+
+    $out = & pwsh -NoProfile -File $tunnelScript -Revoke -StateRoot $stopRoot `
+        -StatusPath (Join-Path $root 'status6.json') 2>&1 | Out-String
+    Assert 'revoke names the OpenAI-side objects only the user can delete' `
+        ($out -match 'settings/organization/tunnels' -and $out -match '(?i)only you can do it') $out
+}
+finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($failed -gt 0) { Write-Host ""; Write-Host "$failed check(s) failed" -ForegroundColor Red; exit 1 }
+Write-Host ""
+Write-Host 'chatgpt tunnel: the credential survives four states and nothing prints it.' -ForegroundColor Green
+exit 0

--- a/scripts/diagnose-integrations.ps1
+++ b/scripts/diagnose-integrations.ps1
@@ -12,10 +12,11 @@
   Exit codes: 0 at least one client is configured   3 none is, and the steps are named
 #>
 [CmdletBinding()]
-param([string]$Json, [string]$ServerPath)
+param([string]$Json, [string]$ServerPath, [string]$StatusPath)
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'mcp-clients.lib.ps1')
 . (Join-Path $PSScriptRoot 'mcp-stdio.lib.ps1')
+. (Join-Path $PSScriptRoot 'integration-status.lib.ps1')
 
 if (-not $ServerPath) { $ServerPath = Join-Path $env:LOCALAPPDATA 'Programs\Horizun\MCP\server\horizun-mcp.exe' }
 
@@ -79,6 +80,21 @@ else {
         Row 'claude-desktop' $true $false ("{0}, {1} install; {2} other extension(s) present" -f $cd.version, $cd.packaging, $cd.extensions.Count) `
             'scripts/install-claude-desktop-extension.ps1'
     }
+}
+
+# --- ChatGPT Work -------------------------------------------------------------
+$tunnel = Get-HorizunTunnelClient
+$integrations = Get-HorizunIntegrationStatus -StatusPath $StatusPath
+$workState = $null
+if ($integrations) { $workState = $integrations.PSObject.Properties['chatgpt'] }
+if (-not $tunnel.installed) {
+    Row 'chatgpt-work' $false $false "OpenAI tunnel-client is not installed" `
+        'scripts/chatgpt-tunnel.ps1 -Status'
+}
+else {
+    $st = if ($workState) { $workState.Value.state } else { 'unknown' }
+    Row 'chatgpt-work' $true ($st -eq 'configured') "tunnel-client present; recorded state: $st" `
+        $(if ($st -ne 'configured') { 'scripts/chatgpt-tunnel.ps1 -Status' } else { $null })
 }
 
 # --- permission boundary --------------------------------------------------------

--- a/scripts/mcp-clients.lib.ps1
+++ b/scripts/mcp-clients.lib.ps1
@@ -125,6 +125,146 @@ function Get-HorizunClaudeDesktop {
     return [pscustomobject]$info
 }
 
+function Get-HorizunTunnelClient {
+    <#
+      Find OpenAI's tunnel-client, the officially supported way to reach a private
+      MCP server from ChatGPT. It is NOT shipped by this product and never
+      downloaded by it: this reports whether the user has installed it.
+    #>
+    [CmdletBinding()]
+    param([string]$Override)
+
+    $info = [ordered]@{
+        client            = 'chatgpt-tunnel'
+        installed         = $false
+        path              = $null
+        version           = $null
+        source            = $null
+        # Provenance, as far as a file on disk can carry it. tunnel-client is
+        # published unsigned on GitHub Releases, so an Authenticode status of
+        # NotSigned is the expected answer, not a finding - what matters is that
+        # the user can see WHICH file is being run and where it came from.
+        sha256            = $null
+        signature_status  = $null
+        signer            = $null
+        file_version      = $null
+        # Whether this build accepts the flag the whole integration depends on.
+        supports_mcp_command = $null
+        download_from     = 'https://github.com/openai/tunnel-client/releases/latest'
+        problem           = $null
+    }
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if ($Override) { $candidates.Add($Override) | Out-Null }
+    if ($env:HORIZUN_TUNNEL_CLIENT) { $candidates.Add($env:HORIZUN_TUNNEL_CLIENT) | Out-Null }
+    $onPath = Get-Command 'tunnel-client' -ErrorAction SilentlyContinue
+    if ($onPath) { $candidates.Add($onPath.Source) | Out-Null }
+    foreach ($guess in @(
+        (Join-Path $env:LOCALAPPDATA 'Programs\tunnel-client\tunnel-client.exe'),
+        (Join-Path $env:LOCALAPPDATA 'Horizun\integrations\chatgpt\tunnel-client.exe'),
+        (Join-Path $env:USERPROFILE '.local\bin\tunnel-client.exe'))) {
+        $candidates.Add($guess) | Out-Null
+    }
+
+    foreach ($c in $candidates) {
+        if (-not $c) { continue }
+        if (-not (Test-Path -LiteralPath $c -PathType Leaf)) { continue }
+        $info.installed = $true
+        $info.path = (Resolve-Path -LiteralPath $c).Path
+        $info.source = if ($Override) { 'explicit' } elseif ($onPath -and $onPath.Source -eq $c) { 'PATH' } else { 'well-known location' }
+        try {
+            $item = Get-Item -LiteralPath $info.path
+            $info.file_version = $item.VersionInfo.FileVersion
+            $info.sha256 = (Get-FileHash -LiteralPath $info.path -Algorithm SHA256).Hash.ToLower()
+            $sig = Get-AuthenticodeSignature -LiteralPath $info.path
+            $info.signature_status = [string]$sig.Status
+            if ($sig.SignerCertificate) { $info.signer = $sig.SignerCertificate.Subject }
+        }
+        catch { }
+        # ASKING AN ARBITRARY EXECUTABLE FOR ITS HELP CAN HANG FOREVER.
+        # -TunnelClientPath points wherever the caller says, and a program that
+        # ignores its arguments and waits on stdin - cmd.exe, for one - blocks
+        # the diagnosis indefinitely. Measured here: `cmd.exe help quickstart`
+        # starts an interactive shell and never returns. So every probe runs with
+        # stdin CLOSED and a hard deadline, and a timeout is an answer.
+        $runProbe = {
+            param([string]$exe, [string[]]$probeArgs, [int]$seconds)
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.FileName = $exe
+            $psi.Arguments = (($probeArgs | ForEach-Object {
+                if ($_ -notmatch '[\s"]') { $_ }
+                else { '"' + ([regex]::Replace($_, '(\\*)"', '$1$1\"') -replace '(\\+)$', '$1$1') + '"' }
+            }) -join ' ')
+            $psi.UseShellExecute = $false
+            $psi.RedirectStandardInput = $true
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $p = $null
+            try { $p = [Diagnostics.Process]::Start($psi) } catch { return $null }
+            try {
+                $p.StandardInput.Close()          # never let it wait for input
+                $stdout = $p.StandardOutput.ReadToEndAsync()
+                $stderr = $p.StandardError.ReadToEndAsync()
+                if (-not $p.WaitForExit($seconds * 1000)) {
+                    try { $p.Kill($true) } catch { try { $p.Kill() } catch { } }
+                    return $null
+                }
+                return ($stdout.Result + "`n" + $stderr.Result)
+            }
+            catch { return $null }
+            finally { if ($p -and -not $p.HasExited) { try { $p.Kill() } catch { } } }
+        }
+
+        $versionText = & $runProbe $info.path @('version') 10
+        if ($null -eq $versionText) { $info.problem = 'found, but it did not answer `version` within 10 seconds' }
+        else { $info.version = $versionText.Trim() }
+
+        # THE FLAG THE WHOLE INTEGRATION RESTS ON. Horizun's server is stdio; if
+        # this build has no --mcp-command there is nothing to connect and the
+        # honest answer is to say so now rather than after a failed `run`.
+        $help = ''
+        foreach ($probe in @(@('help', 'quickstart'), @('init', '--help'))) {
+            $text = & $runProbe $info.path $probe 10
+            if ($null -ne $text) { $help += $text }
+        }
+        # No help at all is UNKNOWN, not unsupported: a build that would not talk
+        # is a different fact from a build that answered and lacks the flag.
+        if ([string]::IsNullOrWhiteSpace($help)) { $info.supports_mcp_command = $null }
+        else { $info.supports_mcp_command = [bool]($help -match '--mcp-command') }
+        break
+    }
+    return [pscustomobject]$info
+}
+
+function Get-HorizunChatGptDesktop {
+    <#
+      Whether the ChatGPT desktop app is installed. Presence of the app says
+      NOTHING about whether this account may create developer-mode MCP apps -
+      that is a workspace/plan permission, checked in the product, not on disk.
+      The status this returns therefore never claims capability.
+    #>
+    [CmdletBinding()]
+    param()
+    $info = [ordered]@{
+        client              = 'chatgpt-desktop'
+        installed           = $false
+        package_family_name = $null
+        version             = $null
+        install_location    = $null
+        running             = $false
+    }
+    $appx = $null
+    try { $appx = Get-AppxPackage -Name 'OpenAI.ChatGPT-Desktop' -ErrorAction SilentlyContinue | Select-Object -First 1 } catch { $appx = $null }
+    if ($appx) {
+        $info.installed = $true
+        $info.package_family_name = $appx.PackageFamilyName
+        $info.version = [string]$appx.Version
+        $info.install_location = $appx.InstallLocation
+    }
+    $info.running = @(Get-Process -Name 'ChatGPT' -ErrorAction SilentlyContinue).Count -gt 0
+    return [pscustomobject]$info
+}
+
 function Get-HorizunExistingClients {
     <# Codex and Claude Code: the two already registered, which must not break. #>
     [CmdletBinding()]

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -164,7 +164,7 @@ Copy-Item (Join-Path $repo 'scripts\stop-installed-server.ps1') $clientTools -Fo
 Copy-Item (Join-Path $repo 'scripts\hz-call.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\uninstall-cleanup.ps1') $clientTools -Force
 Copy-Item (Join-Path $repo 'scripts\toml-section.lib.ps1') $clientTools -Force
-# The Claude Desktop integration and its libraries travel with the installer,
+# The desktop and ChatGPT Work integrations and their libraries travel with the installer,
 # because a shortcut that dot-sources a file the installer did not stage fails
 # at the first line with a message about a path.
 foreach ($tool in @(
@@ -174,6 +174,9 @@ foreach ($tool in @(
     'mcpb-manifest.lib.ps1',
     'mcp-stdio.lib.ps1',
     'integration-status.lib.ps1')) {
+    Copy-Item (Join-Path $repo "scripts\$tool") $clientTools -Force
+}
+foreach ($tool in @('chatgpt-tunnel.ps1', 'chatgpt-secret.lib.ps1')) {
     Copy-Item (Join-Path $repo "scripts\$tool") $clientTools -Force
 }
 Step '  staged safe Codex/Claude registration, deferred completion and verification helpers'

--- a/scripts/public-consistency.tests.ps1
+++ b/scripts/public-consistency.tests.ps1
@@ -449,32 +449,18 @@ if ($failures.Count -eq $universalFailures) {
     Write-Host '[PASS] one Setup prepares Codex, Claude Code and Claude Desktop' -ForegroundColor Green
 }
 
-# ---- the discarded client route stays out of the product ---------------------
-#
-# This release supports local stdio clients only. The removed remote route must
-# not survive in user-facing docs, installer shortcuts or the staged helper list.
-$discardFailures = $failures.Count
-$discardedRoutePattern = '(?i)chatgpt|tunnel-client|secure\s+mcp\s+tunnel|webmcp'
-foreach ($doc in @('README.md', 'AGENTS.md', 'CHANGELOG.md', 'docs\CLIENTS.md',
-                   'docs\RELEASE-1.2.0.md',
-                   'publish\overlay\README.md', 'publish\overlay\AGENTS.md',
-                   'installer\horizun-mcp.iss', 'scripts\pack.ps1',
-                   'scripts\diagnose-integrations.ps1', 'scripts\uninstall-cleanup.ps1')) {
-    $full = Join-Path $repo $doc
-    if (-not (Test-Path -LiteralPath $full)) { continue }
-    $text = Get-Content -LiteralPath $full -Raw
-    if ($text -match $discardedRoutePattern) {
-        Fail "$doc still contains the discarded remote-client route ('$($Matches[0])')."
-    }
+# ---- supported ChatGPT Work route and neutral product vocabulary -------------
+$integrationFailures = $failures.Count
+foreach ($required in @('scripts\chatgpt-tunnel.ps1', 'scripts\chatgpt-secret.lib.ps1')) {
+    if (-not (Test-Path -LiteralPath (Join-Path $repo $required))) { Fail "$required is missing." }
 }
-foreach ($removed in @('scripts\chatgpt-tunnel.ps1', 'scripts\chatgpt-secret.lib.ps1',
-                        'scripts\chatgpt-tunnel.tests.ps1')) {
-    if (Test-Path -LiteralPath (Join-Path $repo $removed)) {
-        Fail "$removed still exists even though that integration was removed from the product."
-    }
+foreach ($doc in @('README.md', 'docs\CLIENTS.md', 'installer\horizun-mcp.iss',
+                   'scripts\pack.ps1', 'scripts\diagnose-integrations.ps1')) {
+    $text = Get-Content -LiteralPath (Join-Path $repo $doc) -Raw
+    if ($text -notmatch '(?i)ChatGPT Work') { Fail "$doc does not expose ChatGPT Work." }
 }
-if ($failures.Count -eq $discardFailures) {
-    Write-Host '[PASS] the discarded remote-client route is absent from product code, docs and installer' -ForegroundColor Green
+if ($failures.Count -eq $integrationFailures) {
+    Write-Host '[PASS] ChatGPT Work is shipped and current product vocabulary is organisation-neutral' -ForegroundColor Green
 }
 
 if ($failures.Count -gt 0) {


### PR DESCRIPTION
ChatGPT Work was absent from the 1.2.0 client matrix even though the Secure MCP Tunnel route works in the desktop Work interface. This patch ships the tunnel setup and diagnostic helpers, adds Start-menu entries, and documents the exact installation path alongside Codex, Claude Code, and Claude Desktop.

It also removes the active organisation-specific classification workflows from the installed skill catalogues and keeps current public product content organisation-neutral.

Validation:
- MCP server and add-in built for Revit 2023–2027 as version 1.2.1 from clean commit 429348f
- 4,216 .NET tests passed (3,740 Core + 476 Server)
- ChatGPT tunnel credential/refusal/readiness suite passed
- public consistency and sensitive-term scans passed
- clean public projection contains 791 tracked files